### PR TITLE
web: change API to use query params for package name and version

### DIFF
--- a/depobs/website/static/do.js
+++ b/depobs/website/static/do.js
@@ -1,8 +1,8 @@
 let httpRequest;
 let parentsRequest;
 
-const PACKAGE_PREFIX = '/package/';
-const PARENTS_PREFIX = '/parents/';
+const PACKAGES_PREFIX = '/packages';
+const PARENTS_PREFIX = '/parents';
 
 window.onload = function() {
     let urlParams = new URLSearchParams(window.location.search);
@@ -15,7 +15,7 @@ window.onload = function() {
 function getPackageInfo(pkg, ver) {
     httpRequest = new XMLHttpRequest();
     httpRequest.onreadystatechange = gotPackageInfo;
-    httpRequest.open('GET', PACKAGE_PREFIX + pkg + '/' + ver);
+    httpRequest.open('GET', PACKAGES_PREFIX + '?' + 'package_name=' + encodeURIComponent(pkg) + '&package_version=' + encodeURIComponent(ver));
     httpRequest.send();
 }
 
@@ -146,7 +146,7 @@ function toggleParents() {
         let ver = urlParams.get('version');
         parentsRequest = new XMLHttpRequest();
         parentsRequest.onreadystatechange = gotParentsInfo;
-        parentsRequest.open('GET', PARENTS_PREFIX + pkg + '/' + ver);
+        parentsRequest.open('GET', PARENTS_PREFIX + '?' + 'package_name=' + encodeURIComponent(pkg) + '&package_version=' + encodeURIComponent(ver));
         parentsRequest.send();
     } else {
         while(table.hasChildNodes()) {

--- a/depobs/website/static/do.js
+++ b/depobs/website/static/do.js
@@ -1,7 +1,7 @@
 let httpRequest;
 let parentsRequest;
 
-const PACKAGES_PREFIX = '/packages';
+const PACKAGES_PREFIX = '/package';
 const PARENTS_PREFIX = '/parents';
 
 window.onload = function() {

--- a/depobs/website/views.py
+++ b/depobs/website/views.py
@@ -1,7 +1,8 @@
 from flask import abort, Response, request, send_from_directory
+from werkzeug.exceptions import BadRequest
 
 from depobs.website import models, app
-from depobs.website.scans import tasks_api
+from depobs.website.scans import tasks_api, validate_npm_package_version_query_params
 from markupsafe import escape
 
 from os import listdir, getcwd
@@ -16,9 +17,16 @@ STANDARD_HEADERS = {
 app.register_blueprint(tasks_api)
 
 
-@app.route('/package/<pkgname>/<version>')
-def show_package_by_name_and_version(pkgname, version):
-    package_report = models.get_package_report(package = pkgname, version = version)
+@app.errorhandler(BadRequest)
+def handle_bad_request(e):
+    return dict(description=e.description), 400
+
+
+@app.route('/packages', methods=["GET"])
+def show_package_by_name_and_version_if_available():
+    package_name, package_version, _ = validate_npm_package_version_query_params()
+
+    package_report = models.get_package_report(package = package_name, version = package_version)
     if None != package_report:
         mimetype = "application/json"
         return Response(json.dumps(package_report.json_with_dependencies()), headers=STANDARD_HEADERS, mimetype=mimetype)
@@ -26,19 +34,12 @@ def show_package_by_name_and_version(pkgname, version):
         #TODO: we probably want to return data to tell the user that a report is being generated
         abort(404)
 
-@app.route('/package/<pkgname>')
-def show_package_by_name(pkgname):
-    package_report = models.get_package_report(package = pkgname)
-    if None != package_report:
-        mimetype = "application/json"
-        return Response(json.dumps(package_report.json_with_dependencies()), headers=STANDARD_HEADERS, mimetype=mimetype)
-    else:
-        #TODO: we probably want to return data to tell the user that a report is being generated
-        abort(404)
 
-@app.route('/parents/<pkgname>/<version>')
-def get_parents_by_name_and_version(pkgname, version):
-    package_report = models.get_package_report(package = pkgname, version = version)
+@app.route('/parents', methods=["GET"])
+def get_parents_by_name_and_version():
+    package_name, package_version, _ = validate_npm_package_version_query_params()
+
+    package_report = models.get_package_report(package = package_name, version = package_version)
     if None != package_report:
         mimetype = "application/json"
         return Response(json.dumps(package_report.json_with_parents()), headers=STANDARD_HEADERS, mimetype=mimetype)

--- a/depobs/website/views.py
+++ b/depobs/website/views.py
@@ -8,7 +8,6 @@ from markupsafe import escape
 from os import listdir, getcwd
 from os.path import exists, isfile, join, dirname
 
-import json
 
 STANDARD_HEADERS = {
     'Access-Control-Allow-Origin' : '*'
@@ -28,8 +27,7 @@ def show_package_by_name_and_version_if_available():
 
     package_report = models.get_package_report(package = package_name, version = package_version)
     if None != package_report:
-        mimetype = "application/json"
-        return Response(json.dumps(package_report.json_with_dependencies()), headers=STANDARD_HEADERS, mimetype=mimetype)
+        return package_report.json_with_dependencies()
     else:
         #TODO: we probably want to return data to tell the user that a report is being generated
         abort(404)
@@ -41,8 +39,7 @@ def get_parents_by_name_and_version():
 
     package_report = models.get_package_report(package = package_name, version = package_version)
     if None != package_report:
-        mimetype = "application/json"
-        return Response(json.dumps(package_report.json_with_parents()), headers=STANDARD_HEADERS, mimetype=mimetype)
+        return package_report.json_with_parents()
     else:
         #TODO: we probably want to return data to tell the user that a report is being generated
         abort(404)
@@ -50,8 +47,7 @@ def get_parents_by_name_and_version():
 
 @app.after_request
 def add_standard_headers_to_static_routes(response):
-    if request.path.startswith('/static'):
-        response.headers.update(STANDARD_HEADERS)
+    response.headers.update(STANDARD_HEADERS)
     return response
 
 

--- a/depobs/website/views.py
+++ b/depobs/website/views.py
@@ -21,7 +21,7 @@ def handle_bad_request(e):
     return dict(description=e.description), 400
 
 
-@app.route('/packages', methods=["GET"])
+@app.route('/package', methods=["GET"])
 def show_package_by_name_and_version_if_available():
     package_name, package_version, _ = validate_npm_package_version_query_params()
 


### PR DESCRIPTION
refs: #66

Also:

* limit them to GET only
* combine `show_package_by_name` and `show_package_by_name_and_version`
* switch `/package` to `/packages` for plurality consistency with `/parents`