### PR TITLE
scoring debugging

### DIFF
--- a/depobs/website/models.py
+++ b/depobs/website/models.py
@@ -211,8 +211,7 @@ def get_ordered_package_deps(name, version):
         return pv[0]
 
     def get_package_from_name_and_version(db_session, name, version):
-        pv = db_session.query(PackageVersion).filter(PackageVersion.name == name, PackageVersion.version == version)
-        return pv[0]
+        return db_session.query(PackageVersion).filter_by(name=name, version=version).first()
     deps = []
     incomplete = False
 

--- a/depobs/website/models.py
+++ b/depobs/website/models.py
@@ -211,12 +211,16 @@ def get_ordered_package_deps(name, version):
         return pv[0]
 
     def get_package_from_name_and_version(db_session, name, version):
-        return db_session.query(PackageVersion).filter_by(name=name, version=version).first()
+        return db_session.query(PackageVersion).filter_by(name=name, version=version).one_or_none()
     deps = []
     incomplete = False
 
     subject = get_package_from_name_and_version(db_session, name, version)
+    if subject is None:
+        print("subject %s %s not found returning empty deps" % (name, version))
+        return []
     print("subject is %s %s %i" % (subject.name, subject.version, subject.id))
+
     dependency_ids = [link.child_package_id for link in db_session.query(PackageLink).filter(PackageLink.parent_package_id == subject.id)]
     print(dependency_ids)
     dependencies = [get_package_from_id(db_session, dependency_id) for dependency_id in dependency_ids]

--- a/depobs/website/models.py
+++ b/depobs/website/models.py
@@ -206,9 +206,10 @@ def get_most_recently_scored_package_report(package_name: str, package_version: 
 
 def get_ordered_package_deps(name, version):
     def get_package_from_id(db_session, id):
-        print(f"get_package_id for {id}")
-        pv = db_session.query(PackageVersion).filter(PackageVersion.id == id)
-        return pv[0]
+        package_version = db_session.query(PackageVersion).filter(PackageVersion.id == id).one_or_none()
+        if package_version is None:
+            print(f"no package found for get_package_id {id}")
+        return package_version
 
     def get_package_from_name_and_version(db_session, name, version):
         return db_session.query(PackageVersion).filter_by(name=name, version=version).one_or_none()
@@ -223,7 +224,8 @@ def get_ordered_package_deps(name, version):
 
     dependency_ids = [link.child_package_id for link in db_session.query(PackageLink).filter(PackageLink.parent_package_id == subject.id)]
     print(dependency_ids)
-    dependencies = [get_package_from_id(db_session, dependency_id) for dependency_id in dependency_ids]
+    maybe_dependencies = [get_package_from_id(db_session, dependency_id) for dependency_id in dependency_ids]
+    dependencies = [dep for dep in maybe_dependencies if dep is not None]
     reports = []
     for dependency in dependencies:
         print(f"dependency {dependency.name} {dependency.version}")

--- a/depobs/website/models.py
+++ b/depobs/website/models.py
@@ -215,8 +215,8 @@ def get_ordered_package_deps(name, version):
     deps = []
     incomplete = False
 
-    subject = db_session.query(PackageVersion).filter(PackageVersion.name == name, PackageVersion.version == version)[0]
-    print("subject  %s %s %i" % (subject.name, subject.version, subject.id))
+    subject = get_package_from_name_and_version(db_session, name, version)
+    print("subject is %s %s %i" % (subject.name, subject.version, subject.id))
     dependency_ids = [link.child_package_id for link in db_session.query(PackageLink).filter(PackageLink.parent_package_id == subject.id)]
     print(dependency_ids)
     dependencies = [get_package_from_id(db_session, dependency_id) for dependency_id in dependency_ids]

--- a/depobs/website/models.py
+++ b/depobs/website/models.py
@@ -184,7 +184,7 @@ def get_package_report(package, version = None):
     if None == version:
         #TODO order-by is hard with semver. Think about splitting out versions
         no_version_query = db_session.query(PackageReport).filter(PackageReport.package==package)
-        print("Query is %s" % str(no_version_query))
+        print(f"Query is {no_version_query}")
         for rep in no_version_query:
             return rep
     else:
@@ -200,13 +200,13 @@ def get_most_recently_scored_package_report(package_name: str, package_version: 
         query = query.filter_by(version=package_version)
     if scored_after is not None:
         query = query.filter(PackageReport.scoring_date >= scored_after)
-    print("Query is %s" % str(query))
+    print(f"Query is {query}")
     return query.order_by(PackageReport.scoring_date.desc()).limit(1).one_or_none()
 
 
 def get_ordered_package_deps(name, version):
     def get_package_from_id(db_session, id):
-        print("get_package_id for %i" % (id))
+        print(f"get_package_id for {id}")
         pv = db_session.query(PackageVersion).filter(PackageVersion.id == id)
         return pv[0]
 
@@ -217,16 +217,16 @@ def get_ordered_package_deps(name, version):
 
     subject = get_package_from_name_and_version(db_session, name, version)
     if subject is None:
-        print("subject %s %s not found returning empty deps" % (name, version))
+        print(f"subject dep {name} {version} not found returning empty deps")
         return []
-    print("subject is %s %s %i" % (subject.name, subject.version, subject.id))
+    print(f"subject is {subject.name} {subject.version} {subject.id}")
 
     dependency_ids = [link.child_package_id for link in db_session.query(PackageLink).filter(PackageLink.parent_package_id == subject.id)]
     print(dependency_ids)
     dependencies = [get_package_from_id(db_session, dependency_id) for dependency_id in dependency_ids]
     reports = []
     for dependency in dependencies:
-        print("dependency  %s %s" % (dependency.name, dependency.version))
+        print(f"dependency {dependency.name} {dependency.version}")
         report = get_package_report(dependency.name, dependency.version)
         if None == report:
             incomplete = True
@@ -234,10 +234,10 @@ def get_ordered_package_deps(name, version):
         else:
             reports.append(report)
     if incomplete:
-        print("dependencies for %s, %s incomplete, re-adding to the queue" % (name, version))
+        print(f"dependencies for {name}, {version} incomplete, re-adding to the queue")
         deps.append((name, version))
     else:
-        print("dependencies complete for %s %s adding to the graph" % (name, version))
+        print(f"dependencies complete for {name}, {version} adding to the graph")
         pr = PackageReport()
         pr.package = name
         pr.version = version

--- a/depobs/website/models.py
+++ b/depobs/website/models.py
@@ -223,12 +223,12 @@ def get_ordered_package_deps(name, version):
     print(f"subject is {subject.name} {subject.version} {subject.id}")
 
     dependency_ids = [link.child_package_id for link in db_session.query(PackageLink).filter(PackageLink.parent_package_id == subject.id)]
-    print(dependency_ids)
+    print(f"found dependency ids for {subject.name} {subject.version}: {dependency_ids}")
     maybe_dependencies = [get_package_from_id(db_session, dependency_id) for dependency_id in dependency_ids]
     dependencies = [dep for dep in maybe_dependencies if dep is not None]
     reports = []
     for dependency in dependencies:
-        print(f"dependency {dependency.name} {dependency.version}")
+        print(f"dependency {dependency.id} {dependency.name} {dependency.version}")
         report = get_package_report(dependency.name, dependency.version)
         if None == report:
             incomplete = True

--- a/depobs/worker/tasks.py
+++ b/depobs/worker/tasks.py
@@ -288,10 +288,10 @@ def build_report_tree(package_version_tuple: Tuple[str, str], visited=None):
     else:
         for (dep_name, dep_version) in deps:
             if tuple([dep_name, dep_version]) in visited:
-                print("skipping building report tree for visited dep %s %s" % (dep_name, dep_version))
+                print(f"skipping building report tree for visited dep  {dep_name} {dep_version}")
                 continue
 
-            print("will build report tree for dep %s %s" % (dep_name, dep_version))
+            print(f"building report tree for dep {dep_name} {dep_version}")
             build_report_tree((dep_name, dep_version), visited)
 
 

--- a/depobs/worker/tasks.py
+++ b/depobs/worker/tasks.py
@@ -283,7 +283,7 @@ def build_report_tree(package_version_tuple: Tuple[str, str]):
         score_package(package_name, package_version)
     else:
         for (dep_name, dep_version) in deps:
-            print("will build report tree  for %s %s", (dep_name, dep_version))
+            print("will build report tree for %s %s" % (dep_name, dep_version))
             build_report_tree((dep_name, dep_version))
 
 

--- a/depobs/worker/tasks.py
+++ b/depobs/worker/tasks.py
@@ -276,15 +276,23 @@ def score_package(package_name: str, package_version: str):
 
 
 @scanner.task()
-def build_report_tree(package_version_tuple: Tuple[str, str]):
+def build_report_tree(package_version_tuple: Tuple[str, str], visited=None):
+    if visited is None:
+        visited = set()
+    visited.add(tuple(package_version_tuple))
+
     package_name, package_version = package_version_tuple
     deps = get_ordered_package_deps(package_name, package_version)
     if len(deps) == 0:
         score_package(package_name, package_version)
     else:
         for (dep_name, dep_version) in deps:
-            print("will build report tree for %s %s" % (dep_name, dep_version))
-            build_report_tree((dep_name, dep_version))
+            if tuple([dep_name, dep_version]) in visited:
+                print("skipping building report tree for visited dep %s %s" % (dep_name, dep_version))
+                continue
+
+            print("will build report tree for dep %s %s" % (dep_name, dep_version))
+            build_report_tree((dep_name, dep_version), visited)
 
 
 @scanner.task()


### PR DESCRIPTION
refs: #100

changes:
* track visited deps in build report tree hopefully fixing issue 100
* logging tweaks
* model fetching error handling for missing dep versions and subjects

functional test:

- [x] after fixtures loaded, ran `./util/call_task_in_worker.sh build_report_tree --args '[["eslint","6.8.0"]]'`  has a cycle in `global-modules@1.0.0 <-> resolve-dir@1.0.1` and it terminated