### PR TITLE
Fix 100 score latest graph

### DIFF
--- a/depobs/website/models.py
+++ b/depobs/website/models.py
@@ -213,6 +213,12 @@ def get_ordered_package_deps(name, version):
 
     def get_package_from_name_and_version(db_session, name, version):
         return db_session.query(PackageVersion).filter_by(name=name, version=version).one_or_none()
+
+    def get_child_package_ids_from_parent_package_id(db_session, parent_package_id: int):
+        return [
+            link.child_package_id for link in db_session.query(PackageLink).filter(PackageLink.parent_package_id == subject.id)
+        ]
+
     deps = []
     incomplete = False
 
@@ -222,7 +228,7 @@ def get_ordered_package_deps(name, version):
         return []
     print(f"subject is {subject.name} {subject.version} {subject.id}")
 
-    dependency_ids = [link.child_package_id for link in db_session.query(PackageLink).filter(PackageLink.parent_package_id == subject.id)]
+    dependency_ids = get_child_package_ids_from_parent_package_id(db_session, subject.id)
     print(f"found dependency ids for {subject.name} {subject.version}: {dependency_ids}")
     maybe_dependencies = [get_package_from_id(db_session, dependency_id) for dependency_id in dependency_ids]
     dependencies = [dep for dep in maybe_dependencies if dep is not None]

--- a/depobs/website/models.py
+++ b/depobs/website/models.py
@@ -204,6 +204,19 @@ def get_most_recently_scored_package_report(package_name: str, package_version: 
     return query.order_by(PackageReport.scoring_date.desc()).limit(1).one_or_none()
 
 
+def get_most_recently_inserted_package_from_name_and_version(
+        package_name: str,
+        package_version: Optional[str]=None,
+        inserted_after: Optional[datetime]=None
+):
+    query = db_session.query(PackageVersion).filter_by(name=package_name)
+    if package_version is not None:
+        query = query.filter_by(version=package_version)
+    if inserted_after is not None:
+        query = query.filter(PackageVersion.inserted_at >= inserted_after)
+    return query.order_by(PackageVersion.inserted_at.desc()).limit(1).one_or_none()
+
+
 def get_ordered_package_deps(name, version):
     def get_package_from_id(db_session, id):
         package_version = db_session.query(PackageVersion).filter(PackageVersion.id == id).one_or_none()

--- a/depobs/website/models.py
+++ b/depobs/website/models.py
@@ -224,9 +224,6 @@ def get_ordered_package_deps(name, version):
             print(f"no package found for get_package_id {id}")
         return package_version
 
-    def get_package_from_name_and_version(db_session, name, version):
-        return db_session.query(PackageVersion).filter_by(name=name, version=version).one_or_none()
-
     def get_child_package_ids_from_parent_package_id(db_session, parent_package_id: int):
         return [
             link.child_package_id for link in db_session.query(PackageLink).filter(PackageLink.parent_package_id == subject.id)
@@ -235,7 +232,7 @@ def get_ordered_package_deps(name, version):
     deps = []
     incomplete = False
 
-    subject = get_package_from_name_and_version(db_session, name, version)
+    subject = get_most_recently_inserted_package_from_name_and_version(name, version)
     if subject is None:
         print(f"subject dep {name} {version} not found returning empty deps")
         return []

--- a/depobs/website/models.py
+++ b/depobs/website/models.py
@@ -233,16 +233,18 @@ def get_latest_graph_including_package_as_parent(package: PackageVersion) -> Opt
 
 def get_ordered_package_deps(name, version):
 
-    def get_child_package_ids_from_parent_package_id(db_session, parent_package_id: int):
-        return [
-            link.child_package_id for link in db_session.query(PackageLink).filter(PackageLink.parent_package_id == subject.id)
-        ]
 
 def get_package_from_id(id: int) -> Optional[PackageVersion]:
     package_version = db_session.query(PackageVersion).filter(PackageVersion.id == id).one_or_none()
     if package_version is None:
         print(f"no package found for get_package_id {id}")
     return package_version
+
+
+def get_child_package_ids_from_parent_package_id(links: List[PackageLink], subject: PackageVersion) -> List[int]:
+    return [
+        link.child_package_id for link in links if link.parent_package_id == subject.id
+    ]
 
 
     deps = []
@@ -254,7 +256,7 @@ def get_package_from_id(id: int) -> Optional[PackageVersion]:
         return []
     print(f"subject is {subject.name} {subject.version} {subject.id}")
 
-    dependency_ids = get_child_package_ids_from_parent_package_id(db_session, subject.id)
+    dependency_ids = get_child_package_ids_from_parent_package_id(links, subject)
     print(f"found dependency ids for {subject.name} {subject.version}: {dependency_ids}")
     maybe_dependencies = [get_package_from_id(dependency_id) for dependency_id in dependency_ids]
     dependencies = [dep for dep in maybe_dependencies if dep is not None]

--- a/depobs/website/models.py
+++ b/depobs/website/models.py
@@ -232,16 +232,18 @@ def get_latest_graph_including_package_as_parent(package: PackageVersion) -> Opt
 
 
 def get_ordered_package_deps(name, version):
-    def get_package_from_id(db_session, id):
-        package_version = db_session.query(PackageVersion).filter(PackageVersion.id == id).one_or_none()
-        if package_version is None:
-            print(f"no package found for get_package_id {id}")
-        return package_version
 
     def get_child_package_ids_from_parent_package_id(db_session, parent_package_id: int):
         return [
             link.child_package_id for link in db_session.query(PackageLink).filter(PackageLink.parent_package_id == subject.id)
         ]
+
+def get_package_from_id(id: int) -> Optional[PackageVersion]:
+    package_version = db_session.query(PackageVersion).filter(PackageVersion.id == id).one_or_none()
+    if package_version is None:
+        print(f"no package found for get_package_id {id}")
+    return package_version
+
 
     deps = []
     incomplete = False
@@ -254,7 +256,7 @@ def get_ordered_package_deps(name, version):
 
     dependency_ids = get_child_package_ids_from_parent_package_id(db_session, subject.id)
     print(f"found dependency ids for {subject.name} {subject.version}: {dependency_ids}")
-    maybe_dependencies = [get_package_from_id(db_session, dependency_id) for dependency_id in dependency_ids]
+    maybe_dependencies = [get_package_from_id(dependency_id) for dependency_id in dependency_ids]
     dependencies = [dep for dep in maybe_dependencies if dep is not None]
     reports = []
     for dependency in dependencies:

--- a/depobs/website/models.py
+++ b/depobs/website/models.py
@@ -2,7 +2,7 @@
 
 import os
 from datetime import datetime
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from sqlalchemy import create_engine, Column, Integer, Float, String, DateTime, \
      ForeignKey, event, select
@@ -231,7 +231,6 @@ def get_latest_graph_including_package_as_parent(package: PackageVersion) -> Opt
     return graph_query.one_or_none()
 
 
-def get_ordered_package_deps(name, version):
 def get_graph_links(graph: PackageGraph) -> List[PackageLink]:
     return db_session.query(PackageLink).filter(PackageLink.id.in_([lid[0] for lid in graph.link_ids])).all()
 
@@ -249,6 +248,7 @@ def get_child_package_ids_from_parent_package_id(links: List[PackageLink], subje
     ]
 
 
+def get_ordered_package_deps(links: List[PackageLink], name: str, version: str) -> List[Tuple[str, str]]:
     deps = []
     incomplete = False
 

--- a/depobs/website/models.py
+++ b/depobs/website/models.py
@@ -232,6 +232,8 @@ def get_latest_graph_including_package_as_parent(package: PackageVersion) -> Opt
 
 
 def get_ordered_package_deps(name, version):
+def get_graph_links(graph: PackageGraph) -> List[PackageLink]:
+    return db_session.query(PackageLink).filter(PackageLink.id.in_([lid[0] for lid in graph.link_ids])).all()
 
 
 def get_package_from_id(id: int) -> Optional[PackageVersion]:


### PR DESCRIPTION
fixes: #100

Changes:
* only score the subgraph from the latest link in which the package is a parent (we might find the dependency in multiple graphs but only care the the score for the most recent one) 
* fetch all links for a graph once instead of querying along the way (perf-wise assuming relatively few links in a graph and that the dependency uses most of them)