### PR TITLE
Expose the fact we've had an error

### DIFF
--- a/depobs/website/models.py
+++ b/depobs/website/models.py
@@ -44,6 +44,7 @@ class PackageReport(TaskIDMixin, Model):
 
     package = Column(String(200))
     version = Column(String(200))
+    status = Column(String(200))
     release_date = Column(DateTime)
     scoring_date = Column(DateTime)
     top_score = Column(Integer)
@@ -78,6 +79,7 @@ class PackageReport(TaskIDMixin, Model):
             task_status=self.task_status,
             package=self.package,
             version=self.version,
+            status=self.status,
             release_date=self.release_date,
             scoring_date=self.scoring_date,
             top_score=self.top_score,
@@ -109,6 +111,7 @@ class PackageLatestReport(View_only):
 
     package = Column(String(200))
     version = Column(String(200))
+    status = Column(String(200))
     release_date = Column(DateTime)
     scoring_date = Column(DateTime)
     top_score = Column(Integer)
@@ -139,6 +142,7 @@ class PackageLatestReport(View_only):
             id=self.id,
             package=self.package,
             version=self.version,
+            status=self.status,
             release_date=self.release_date,
             scoring_date=self.scoring_date,
             top_score=self.top_score,
@@ -163,6 +167,7 @@ class PackageLatestReport(View_only):
             id=self.id,
             package=self.package,
             version=self.version,
+            status=self.status,
             release_date=self.release_date,
             scoring_date=self.scoring_date,
             top_score=self.top_score,
@@ -352,6 +357,7 @@ def insert_package_report_placeholder_or_update_task_id(package_name: str, packa
         pr = PackageReport()
         pr.package = package_name
         pr.version = package_version
+        pr.status = "scanning"
         pr.task_id = task_id
     store_package_report(pr)
     return pr

--- a/depobs/website/views.py
+++ b/depobs/website/views.py
@@ -58,6 +58,8 @@ def handle_package_report_not_found(e):
     # Is there a placeholder entry?
     package_report = models.get_placeholder_entry(package_name, package_version)
     if package_report:
+        if package_report.status == "error":
+            return package_report.report_json, 500
         return package_report.report_json, 202
     
     if not tasks.check_npm_package_exists(package_name, package_version):

--- a/depobs/worker/tasks.py
+++ b/depobs/worker/tasks.py
@@ -35,6 +35,7 @@ from depobs.website.models import (
     store_package_reports,
     get_most_recently_inserted_package_from_name_and_version,
     get_latest_graph_including_package_as_parent,
+    get_placeholder_entry,
     get_networkx_graph_and_nodes,
 )
 
@@ -258,6 +259,7 @@ def score_package(
         )
 
     pr.scoring_date = datetime.datetime.now()
+    pr.status = "scanned"
     return pr
 
 
@@ -321,6 +323,10 @@ def build_report_tree(package_version_tuple: Tuple[str, str]) -> None:
 
     package: Optional[PackageVersion] = get_most_recently_inserted_package_from_name_and_version(package_name, package_version)
     if package is None:
+        pr = get_placeholder_entry(package_name, package_version)
+        if pr:
+            pr.status = "error"
+            store_package_report(pr)
         raise Exception(f"PackageVersion not found for {package_name} {package_version}.")
 
     graph: Optional[PackageGraph] = get_latest_graph_including_package_as_parent(package)


### PR DESCRIPTION
This added an 'status' field to the report table.
This allows us to expose the fact we've had an error to the UI, although
its not a very nice error atm :)
To test:
http://localhost:8000/?manager=npm&package=async&version=3.2.0
Initially this will show the 'come back later' message.
But after the job fails it will show the 'unexpected error' message.