### PR TITLE
prune deps

### DIFF
--- a/depobs/Dockerfile
+++ b/depobs/Dockerfile
@@ -28,7 +28,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
             build-essential \
             libpq-dev \
             graphviz \
-	    jq \
             && \
         curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
         add-apt-repository \

--- a/depobs/Dockerfile
+++ b/depobs/Dockerfile
@@ -22,23 +22,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
         apt-get install --no-install-recommends -y \
             apt-transport-https \
             ca-certificates \
-            curl \
-            gnupg2 \
-            software-properties-common \
             build-essential \
             libpq-dev \
-            graphviz \
-            && \
-        curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
-        add-apt-repository \
-            "deb [arch=amd64] https://download.docker.com/linux/debian \
-            $(lsb_release -cs) \
-            stable" && \
-        DEBIAN_FRONTEND=noninteractive apt-get update && \
-        apt-get install --no-install-recommends -y \
-            docker-ce \
-            docker-ce-cli \
-            containerd.io
+            graphviz
 
 WORKDIR /app
 

--- a/depobs/requirements.txt
+++ b/depobs/requirements.txt
@@ -33,8 +33,6 @@ py==1.8.1
 pydot==1.4.1
 pyparsing==2.4.7
 pytest-asyncio==0.11.0
-pytest-codestyle==2.0.1
-pytest-cov==2.8.1
 pytest==5.4.1
 quiz==0.2.0
 regex==2020.4.4


### PR DESCRIPTION
Changes:

* remove unused OS packages for docker CLI
* remove some -scanner dev requirements

This should speed up the build-images CI job.

edit: looks like it doesn't hurt

 The last master build took ~3m https://circleci.com/workflow-run/b541cbea-7e57-4aba-afb0-f084aead0d86 and this one took 2m6s https://app.circleci.com/pipelines/github/mozilla-services/dependency-observatory/414/workflows/5a10131b-2442-45b9-865c-6115803c1aa3