### PR TITLE
Test scoring

### DIFF
--- a/depobs/requirements.txt
+++ b/depobs/requirements.txt
@@ -33,6 +33,7 @@ py==1.8.1
 pydot==1.4.1
 pyparsing==2.4.7
 pytest-asyncio==0.11.0
+pytest-mock==3.1.0
 pytest==5.4.1
 quiz==0.2.0
 regex==2020.4.4

--- a/depobs/scanner/graph_traversal.py
+++ b/depobs/scanner/graph_traversal.py
@@ -1,0 +1,79 @@
+from typing import (
+    Generator,
+    Set,
+)
+
+import networkx as nx
+from networkx.algorithms.components import condensation
+from networkx.algorithms.dag import is_directed_acyclic_graph
+
+
+# type alias to not confuse ints as nxGraphNodeIDs with other ints
+nxGraphNodeID = int
+
+
+def outer_in_graph_iter(g: nx.DiGraph) -> Generator[Set[nxGraphNodeID], None, None]:
+    """For a directed graph with unique node IDs with type int, iterates
+    from outer / leafmost / least depended upon nodes to inner nodes
+    yielding sets of node IDs.
+
+    Properties:
+
+    * yields each node ID once
+    * successive node ID sets only depend on/point to previously visited
+    nodes or other nodes within their set
+    """
+    if len(g.nodes) == 0:
+        raise StopIteration("graph has no nodes")
+
+    # > C – The condensation graph C of G. The node labels are integers
+    # > corresponding to the index of the component in the list of strongly
+    # > connected components of G. C has a graph attribute named ‘mapping’ with
+    # > a dictionary mapping the original nodes to the nodes in C to which they
+    # > belong. Each node in C also has a node attribute ‘members’ with the set
+    # > of original nodes in G that form the SCC that the node in C represents.
+    #
+    # https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.components.condensation.html#networkx.algorithms.components.condensation
+    c = condensation(g)
+    assert is_directed_acyclic_graph(c)
+    for scc_ids in outer_in_iter(c):
+        # translate scc node ids back into G node ids
+        g_node_ids: Set[nxGraphNodeID] = set()
+        g_node_ids.update(*[c.nodes[scc_id]["members"] for scc_id in scc_ids])
+        yield g_node_ids
+
+
+def outer_in_iter(g: nx.DiGraph) -> Generator[Set[nxGraphNodeID], None, None]:
+    """
+    For a DAG with unique node IDs with type int, iterates from outer
+    / leafmost / least depended upon nodes to inner nodes yielding sets
+    of node IDs.
+
+    Yields each node ID once and visits them such that successive node ID sets
+    only depend on/point to previously visited nodes.
+    """
+    if len(g.nodes) == 0:
+        raise StopIteration("graph has no nodes")
+    if len(g.nodes) > 1 and not is_directed_acyclic_graph(g):
+        raise Exception("graph has more than one node and is not a DAG")
+
+    visited: Set[nxGraphNodeID] = set()
+    leaf_nodes: Set[nxGraphNodeID] = set(
+        [node for node in g.nodes() if g.out_degree(node) == 0]
+    )
+    yield leaf_nodes
+    visited.update(leaf_nodes)
+
+    while True:
+        points_to_visited = set(src for (src, _) in g.in_edges(visited))
+        only_points_to_visited = set(
+            node
+            for node in points_to_visited
+            if all(dst in visited for (_, dst) in g.out_edges(node))
+        )
+        new_only_points_to_visited = only_points_to_visited - visited
+        if not bool(new_only_points_to_visited):  # visited nothing new
+            assert len(visited) == len(g.nodes)
+            break
+        yield new_only_points_to_visited
+        visited.update(only_points_to_visited)

--- a/depobs/website/config.py
+++ b/depobs/website/config.py
@@ -24,6 +24,7 @@ LOGGING = {
         "request.summary": {"handlers": ["console"], "level": "INFO"},
         "depobs.website.models": {"handlers": ["console"], "level": "INFO"},
         "depobs.worker.tasks": {"handlers": ["console"], "level": "INFO"},
+        "depobs.worker.scoring": {"handlers": ["console"], "level": "INFO",},
         "depobs.scanner.clients.cratesio": {"handlers": ["console"], "level": "INFO"},
         "depobs.scanner.clients.npmsio": {"handlers": ["console"], "level": "INFO"},
         "depobs.scanner.clients.npm_registry": {

--- a/depobs/worker/scoring.py
+++ b/depobs/worker/scoring.py
@@ -1,0 +1,137 @@
+from datetime import datetime
+import logging
+from typing import Dict, List
+
+import networkx as nx
+from networkx.algorithms.dag import descendants
+
+from depobs.scanner.db.schema import PackageVersion
+from depobs.scanner.graph_traversal import outer_in_graph_iter
+from depobs.website.models import (
+    PackageReport,
+    PackageLatestReport,
+    get_npms_io_score,
+    get_npm_registry_data,
+    get_vulnerability_counts,
+)
+
+log = logging.getLogger(__name__)
+
+
+def score_package(
+    package_name: str,
+    package_version: str,
+    direct_dep_reports: List[PackageReport],
+    all_deps_count: int = 0,
+) -> PackageReport:
+    log.info(
+        f"scoring package: {package_name}@{package_version} with direct deps {list((r.package, r.version) for r in direct_dep_reports)}"
+    )
+    pr = PackageReport()
+    pr.package = package_name
+    pr.version = package_version
+
+    plr = PackageLatestReport()
+    plr.package = package_name
+    plr.version = package_version
+
+    pr.npmsio_score = get_npms_io_score(package_name, package_version).first()
+
+    pr.directVulnsCritical_score = 0
+    pr.directVulnsHigh_score = 0
+    pr.directVulnsMedium_score = 0
+    pr.directVulnsLow_score = 0
+
+    # Direct vulnerability counts
+    for package, version, severity, count in get_vulnerability_counts(
+        package_name, package_version
+    ):
+        severity = severity.lower()
+        log.info(
+            f"scoring package: {package_name}@{package_version} found vulnerable dep: \t{package}\t{version}\t{severity}\t{count}"
+        )
+        if severity == "critical":
+            pr.directVulnsCritical_score = count
+        elif severity == "high":
+            pr.directVulnsHigh_score = count
+        elif severity in ("medium", "moderate"):
+            pr.directVulnsMedium_score = count
+        elif severity == "low":
+            pr.directVulnsLow_score = count
+        else:
+            log.error(
+                f"unexpected severity {severity} for package {package} / version {version}"
+            )
+
+    for published_at, maintainers, contributors in get_npm_registry_data(
+        package_name, package_version
+    ):
+        pr.release_date = published_at
+        if maintainers is not None:
+            pr.authors = len(maintainers)
+        else:
+            pr.authors = 0
+        if contributors is not None:
+            pr.contributors = len(contributors)
+        else:
+            pr.contributors = 0
+
+    pr.immediate_deps = len(direct_dep_reports)
+    pr.all_deps = all_deps_count
+
+    # Indirect counts
+    pr.indirectVulnsCritical_score = 0
+    pr.indirectVulnsHigh_score = 0
+    pr.indirectVulnsMedium_score = 0
+    pr.indirectVulnsLow_score = 0
+
+    dep_rep_count = 0
+    for report in direct_dep_reports:
+        dep_rep_count += 1
+        for severity in ("Critical", "High", "Medium", "Low"):
+            setattr(
+                pr,
+                f"indirectVulns{severity}_score",
+                getattr(report, f"directVulns{severity}_score", 0)
+                + getattr(report, f"indirectVulns{severity}_score", 0),
+            )
+        pr.dependencies.append(report)
+
+    if dep_rep_count != pr.immediate_deps:
+        log.error(
+            f"expected {pr.immediate_deps} dependencies but got {dep_rep_count} for package {package_name} / version {package_version}"
+        )
+
+    pr.scoring_date = datetime.now()
+    pr.status = "scanned"
+    return pr
+
+
+def score_package_and_children(
+    g: nx.DiGraph, package_versions: List[PackageVersion]
+) -> List[PackageReport]:
+    # refs: https://github.com/mozilla-services/dependency-observatory/issues/130#issuecomment-608017713
+    package_versions_by_id: Dict[int, PackageVersion] = {
+        pv.id: pv for pv in package_versions
+    }
+    # fill this up
+    package_reports_by_id: Dict[int, PackageReport] = {}
+
+    for package_version_ids in outer_in_graph_iter(g):
+        # TODO: score connected component of package_version_ids
+
+        for package_version_id in package_version_ids:
+            package = package_versions_by_id[package_version_id]
+            package_reports_by_id[package_version_id] = score_package(
+                package.name,
+                package.version,
+                direct_dep_reports=[
+                    package_reports_by_id[direct_dep_package_version_id]
+                    for direct_dep_package_version_id in g.successors(
+                        package_version_id
+                    )
+                ],
+                all_deps_count=len(descendants(g, package_version_id)),
+            )
+
+    return list(package_reports_by_id.values())

--- a/depobs/worker/scoring.py
+++ b/depobs/worker/scoring.py
@@ -86,9 +86,7 @@ def score_package(
     pr.indirectVulnsMedium_score = 0
     pr.indirectVulnsLow_score = 0
 
-    dep_rep_count = 0
     for report in direct_dep_reports:
-        dep_rep_count += 1
         for severity in ("Critical", "High", "Medium", "Low"):
             current_count = getattr(pr, f"indirectVulns{severity}_score", 0)
             dep_vuln_count = (
@@ -98,11 +96,6 @@ def score_package(
                 pr, f"indirectVulns{severity}_score", current_count + dep_vuln_count,
             )
         pr.dependencies.append(report)
-
-    if dep_rep_count != pr.immediate_deps:
-        log.error(
-            f"expected {pr.immediate_deps} dependencies but got {dep_rep_count} for package {package_name} / version {package_version}"
-        )
 
     pr.scoring_date = datetime.now()
     pr.status = "scanned"

--- a/depobs/worker/scoring.py
+++ b/depobs/worker/scoring.py
@@ -35,6 +35,7 @@ def score_package(
     plr.package = package_name
     plr.version = package_version
 
+    # NB: raises for a missing score
     pr.npmsio_score = get_npms_io_score(package_name, package_version).first()
 
     pr.directVulnsCritical_score = 0
@@ -89,11 +90,12 @@ def score_package(
     for report in direct_dep_reports:
         dep_rep_count += 1
         for severity in ("Critical", "High", "Medium", "Low"):
+            current_count = getattr(pr, f"indirectVulns{severity}_score", 0)
+            dep_vuln_count = (
+                getattr(report, f"directVulns{severity}_score", 0) or 0
+            ) + (getattr(report, f"indirectVulns{severity}_score", 0) or 0)
             setattr(
-                pr,
-                f"indirectVulns{severity}_score",
-                getattr(report, f"directVulns{severity}_score", 0)
-                + getattr(report, f"indirectVulns{severity}_score", 0),
+                pr, f"indirectVulns{severity}_score", current_count + dep_vuln_count,
             )
         pr.dependencies.append(report)
 

--- a/depobs/worker/tasks.py
+++ b/depobs/worker/tasks.py
@@ -25,6 +25,7 @@ import celery.result
 from flask import current_app
 import networkx as nx
 from networkx.algorithms.dag import descendants, is_directed_acyclic_graph
+from networkx.algorithms.components import condensation
 
 from depobs.website.do import create_celery_app
 import depobs.website.models as models
@@ -334,6 +335,37 @@ def score_package(
     return pr
 
 
+def outer_in_graph_iter(g: nx.DiGraph) -> Generator[List[int], None, None]:
+    """For a directed graph with unique node IDs with type int, iterates
+    from outer / leafmost / least depended upon nodes to inner nodes
+    yielding sets of node IDs.
+
+    Properties:
+
+    * yields each node ID once
+    * successive node ID sets only depend on/point to previously visited
+    nodes or other nodes within their set
+    """
+    if len(g.nodes) == 0:
+        raise StopIteration("graph has no nodes")
+
+    # > C – The condensation graph C of G. The node labels are integers
+    # > corresponding to the index of the component in the list of strongly
+    # > connected components of G. C has a graph attribute named ‘mapping’ with
+    # > a dictionary mapping the original nodes to the nodes in C to which they
+    # > belong. Each node in C also has a node attribute ‘members’ with the set
+    # > of original nodes in G that form the SCC that the node in C represents.
+    #
+    # https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.components.condensation.html#networkx.algorithms.components.condensation
+    c = condensation(g)
+    assert is_directed_acyclic_graph(c)
+    for scc_ids in outer_in_iter(c):
+        # translate scc node ids back into G node ids
+        g_node_ids = set()
+        g_node_ids.update(*[c.nodes[scc_id]["members"] for scc_id in scc_ids])
+        yield g_node_ids
+
+
 def outer_in_iter(g: nx.DiGraph) -> Generator[List[int], None, None]:
     """
     For a DAG with unique node IDs with type int, iterates from outer
@@ -343,10 +375,10 @@ def outer_in_iter(g: nx.DiGraph) -> Generator[List[int], None, None]:
     Yields each node ID once and visits them such that successive node ID sets
     only depend on/point to previously visited nodes.
     """
-    if len(g.edges) == 0 or len(g.nodes) == 0:
-        raise Exception("graph has no edges or nodes")
-    if not is_directed_acyclic_graph(g):
-        raise Exception("graph is not a DAG")
+    if len(g.nodes) == 0:
+        raise StopIteration("graph has no nodes")
+    if len(g.nodes) > 1 and not is_directed_acyclic_graph(g):
+        raise Exception("graph has more than one node and is not a DAG")
 
     visited: AbstractSet[int] = set()
     leaf_nodes = set([node for node in g.nodes() if g.out_degree(node) == 0])

--- a/depobs/worker/tasks.py
+++ b/depobs/worker/tasks.py
@@ -24,8 +24,7 @@ from celery.utils.log import get_task_logger
 import celery.result
 from flask import current_app
 import networkx as nx
-from networkx.algorithms.dag import descendants, is_directed_acyclic_graph
-from networkx.algorithms.components import condensation
+from networkx.algorithms.dag import descendants
 
 from depobs.website.do import create_celery_app
 import depobs.website.models as models
@@ -56,6 +55,7 @@ from depobs.scanner.db.schema import (
     PackageVersion,
     PackageGraph,
 )
+from depobs.scanner.graph_traversal import outer_in_iter
 from depobs.scanner.pipelines.postprocess import postprocess_task
 from depobs.scanner.pipelines.run_repo_tasks import (
     iter_task_envs,
@@ -333,71 +333,6 @@ def score_package(
     pr.scoring_date = datetime.datetime.now()
     pr.status = "scanned"
     return pr
-
-
-def outer_in_graph_iter(g: nx.DiGraph) -> Generator[List[int], None, None]:
-    """For a directed graph with unique node IDs with type int, iterates
-    from outer / leafmost / least depended upon nodes to inner nodes
-    yielding sets of node IDs.
-
-    Properties:
-
-    * yields each node ID once
-    * successive node ID sets only depend on/point to previously visited
-    nodes or other nodes within their set
-    """
-    if len(g.nodes) == 0:
-        raise StopIteration("graph has no nodes")
-
-    # > C – The condensation graph C of G. The node labels are integers
-    # > corresponding to the index of the component in the list of strongly
-    # > connected components of G. C has a graph attribute named ‘mapping’ with
-    # > a dictionary mapping the original nodes to the nodes in C to which they
-    # > belong. Each node in C also has a node attribute ‘members’ with the set
-    # > of original nodes in G that form the SCC that the node in C represents.
-    #
-    # https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.components.condensation.html#networkx.algorithms.components.condensation
-    c = condensation(g)
-    assert is_directed_acyclic_graph(c)
-    for scc_ids in outer_in_iter(c):
-        # translate scc node ids back into G node ids
-        g_node_ids = set()
-        g_node_ids.update(*[c.nodes[scc_id]["members"] for scc_id in scc_ids])
-        yield g_node_ids
-
-
-def outer_in_iter(g: nx.DiGraph) -> Generator[List[int], None, None]:
-    """
-    For a DAG with unique node IDs with type int, iterates from outer
-    / leafmost / least depended upon nodes to inner nodes yielding sets
-    of node IDs.
-
-    Yields each node ID once and visits them such that successive node ID sets
-    only depend on/point to previously visited nodes.
-    """
-    if len(g.nodes) == 0:
-        raise StopIteration("graph has no nodes")
-    if len(g.nodes) > 1 and not is_directed_acyclic_graph(g):
-        raise Exception("graph has more than one node and is not a DAG")
-
-    visited: AbstractSet[int] = set()
-    leaf_nodes = set([node for node in g.nodes() if g.out_degree(node) == 0])
-    yield leaf_nodes
-    visited.update(leaf_nodes)
-
-    while True:
-        points_to_visited = set(src for (src, _) in g.in_edges(visited))
-        only_points_to_visited = set(
-            node
-            for node in points_to_visited
-            if all(dst in visited for (_, dst) in g.out_edges(node))
-        )
-        new_only_points_to_visited = only_points_to_visited - visited
-        if not bool(new_only_points_to_visited):  # visited nothing new
-            assert len(visited) == len(g.nodes)
-            break
-        yield new_only_points_to_visited
-        visited.update(only_points_to_visited)
 
 
 def score_package_and_children(g: nx.DiGraph, package_versions: List[PackageVersion]):

--- a/depobs/worker/tasks.py
+++ b/depobs/worker/tasks.py
@@ -23,8 +23,6 @@ import celery
 from celery.utils.log import get_task_logger
 import celery.result
 from flask import current_app
-import networkx as nx
-from networkx.algorithms.dag import descendants
 
 from depobs.website.do import create_celery_app
 import depobs.website.models as models
@@ -45,6 +43,7 @@ from depobs.website.models import (
     get_placeholder_entry,
     get_networkx_graph_and_nodes,
 )
+from depobs.worker.scoring import score_package, score_package_and_children
 import depobs.worker.validators as validators
 
 # import exc_to_str to resolve import cycle for the following depobs.scanner.clients
@@ -55,7 +54,6 @@ from depobs.scanner.db.schema import (
     PackageVersion,
     PackageGraph,
 )
-from depobs.scanner.graph_traversal import outer_in_iter
 from depobs.scanner.pipelines.postprocess import postprocess_task
 from depobs.scanner.pipelines.run_repo_tasks import (
     iter_task_envs,
@@ -78,6 +76,8 @@ log = get_task_logger(__name__)
 
 
 app = create_celery_app()
+
+score_package = app.task(score_package)
 
 
 @app.task()
@@ -243,118 +243,6 @@ def scan_npm_package(
             )
 
     return (package_name, package_version)
-
-
-@app.task()
-def score_package(
-    package_name: str,
-    package_version: str,
-    direct_dep_reports: List[PackageReport],
-    all_deps_count: int = 0,
-) -> PackageReport:
-    log.info(
-        f"scoring package: {package_name}@{package_version} with direct deps {list((r.package, r.version) for r in direct_dep_reports)}"
-    )
-    pr = PackageReport()
-    pr.package = package_name
-    pr.version = package_version
-
-    pr.npmsio_score = get_npms_io_score(package_name, package_version).first()
-
-    pr.directVulnsCritical_score = 0
-    pr.directVulnsHigh_score = 0
-    pr.directVulnsMedium_score = 0
-    pr.directVulnsLow_score = 0
-
-    # Direct vulnerability counts
-    for package, version, severity, count in get_vulnerability_counts(
-        package_name, package_version
-    ):
-        severity = severity.lower()
-        log.info(
-            f"scoring package: {package_name}@{package_version} found vulnerable dep: \t{package}\t{version}\t{severity}\t{count}"
-        )
-        if severity == "critical":
-            pr.directVulnsCritical_score = count
-        elif severity == "high":
-            pr.directVulnsHigh_score = count
-        elif severity in ("medium", "moderate"):
-            pr.directVulnsMedium_score = count
-        elif severity == "low":
-            pr.directVulnsLow_score = count
-        else:
-            log.error(
-                f"unexpected severity {severity} for package {package} / version {version}"
-            )
-
-    for published_at, maintainers, contributors in get_npm_registry_data(
-        package_name, package_version
-    ):
-        pr.release_date = published_at
-        if maintainers is not None:
-            pr.authors = len(maintainers)
-        else:
-            pr.authors = 0
-        if contributors is not None:
-            pr.contributors = len(contributors)
-        else:
-            pr.contributors = 0
-
-    pr.immediate_deps = len(direct_dep_reports)
-    pr.all_deps = all_deps_count
-
-    # Indirect counts
-    pr.indirectVulnsCritical_score = 0
-    pr.indirectVulnsHigh_score = 0
-    pr.indirectVulnsMedium_score = 0
-    pr.indirectVulnsLow_score = 0
-
-    dep_rep_count = 0
-    for report in direct_dep_reports:
-        dep_rep_count += 1
-        for severity in ("Critical", "High", "Medium", "Low"):
-            setattr(
-                pr,
-                f"indirectVulns{severity}_score",
-                getattr(report, f"directVulns{severity}_score", 0)
-                + getattr(report, f"indirectVulns{severity}_score", 0),
-            )
-        pr.dependencies.append(report)
-
-    if dep_rep_count != pr.immediate_deps:
-        log.error(
-            f"expected {pr.immediate_deps} dependencies but got {dep_rep_count} for package {package_name} / version {package_version}"
-        )
-
-    pr.scoring_date = datetime.datetime.now()
-    pr.status = "scanned"
-    return pr
-
-
-def score_package_and_children(g: nx.DiGraph, package_versions: List[PackageVersion]):
-    # refs: https://github.com/mozilla-services/dependency-observatory/issues/130#issuecomment-608017713
-    package_versions_by_id: Dict[int, PackageVersion] = {
-        pv.id: pv for pv in package_versions
-    }
-    # fill this up
-    package_reports_by_id: Dict[int, PackageReport] = {}
-
-    for package_version_ids in outer_in_iter(g):
-        for package_version_id in package_version_ids:
-            package = package_versions_by_id[package_version_id]
-            package_reports_by_id[package_version_id] = score_package(
-                package.name,
-                package.version,
-                direct_dep_reports=[
-                    package_reports_by_id[direct_dep_package_version_id]
-                    for direct_dep_package_version_id in g.successors(
-                        package_version_id
-                    )
-                ],
-                all_deps_count=len(descendants(g, package_version_id)),
-            )
-
-    return package_reports_by_id.values()
 
 
 @app.task()

--- a/depobs/worker/tasks.py
+++ b/depobs/worker/tasks.py
@@ -259,10 +259,6 @@ def score_package(
     pr.package = package_name
     pr.version = package_version
 
-    plr = PackageLatestReport()
-    plr.package = package_name
-    plr.version = package_version
-
     pr.npmsio_score = get_npms_io_score(package_name, package_version).first()
 
     pr.directVulnsCritical_score = 0

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,8 @@ files =
       depobs/scanner/docker/*.py,
       depobs/scanner/models/*.py,
       depobs/scanner/pipelines/__init__.py,
-      depobs/website/models.py
+      depobs/website/models.py,
+      depobs/worker/scoring.py
 
 python_version = 3.8
 # compose mounts . into /app and mypy can't write to its default .mypy_cache dir
@@ -48,14 +49,21 @@ warn_unused_configs = True
 
 [mypy-depobs.website.models]
 check_untyped_defs = True
-disallow_incomplete_defs = True
-disallow_untyped_calls = True
-disallow_untyped_decorators = True
 disallow_untyped_defs = True
+disallow_untyped_calls = True
+disallow_incomplete_defs = True
+disallow_untyped_decorators = True
+
+[mypy-depobs.worker.scoring]
+check_untyped_defs = True
+disallow_untyped_defs = True
+disallow_untyped_calls = True
+disallow_incomplete_defs = True
+disallow_untyped_decorators = True
 
 [mypy-depobs.scanner.graph_traversal]
 check_untyped_defs = True
-disallow_incomplete_defs = True
-disallow_untyped_calls = True
-disallow_untyped_decorators = True
 disallow_untyped_defs = True
+disallow_untyped_calls = True
+disallow_incomplete_defs = True
+disallow_untyped_decorators = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,3 +52,10 @@ disallow_incomplete_defs = True
 disallow_untyped_calls = True
 disallow_untyped_decorators = True
 disallow_untyped_defs = True
+
+[mypy-depobs.scanner.graph_traversal]
+check_untyped_defs = True
+disallow_incomplete_defs = True
+disallow_untyped_calls = True
+disallow_untyped_decorators = True
+disallow_untyped_defs = True

--- a/tests/scanner/unit/test_graph_traversal.py
+++ b/tests/scanner/unit/test_graph_traversal.py
@@ -1,15 +1,17 @@
+# -*- coding: utf-8 -*-
+
 import pytest
 
-import depobs.worker.tasks as tasks
+import depobs.scanner.graph_traversal as m
 
 
 outer_in_iter_failing_testcases = {
-    "no_nodes_no_edges": tasks.nx.empty_graph(n=0, create_using=tasks.nx.DiGraph),
-    "self_loop": (tasks.nx.DiGraph([(0, 0)]), [set([0])],),
-    "two_node_loop": tasks.nx.DiGraph([(0, 1), (1, 0)]),
-    "three_node_loop": tasks.nx.DiGraph([(0, 1), (1, 2), (2, 0)]),
-    "two_two_node_loops": tasks.nx.DiGraph([(0, 1), (1, 0), (0, 2), (2, 0)]),
-    "nested_three_and_two_node_loops": tasks.nx.DiGraph(
+    "no_nodes_no_edges": m.nx.empty_graph(n=0, create_using=m.nx.DiGraph),
+    "self_loop": (m.nx.DiGraph([(0, 0)]), [set([0])],),
+    "two_node_loop": m.nx.DiGraph([(0, 1), (1, 0)]),
+    "three_node_loop": m.nx.DiGraph([(0, 1), (1, 2), (2, 0)]),
+    "two_two_node_loops": m.nx.DiGraph([(0, 1), (1, 0), (0, 2), (2, 0)]),
+    "nested_three_and_two_node_loops": m.nx.DiGraph(
         [(0, 1), (1, 2), (2, 0), (0, 1), (1, 0), (0, 2), (2, 0)]
     ),
 }
@@ -22,20 +24,17 @@ outer_in_iter_failing_testcases = {
 )
 def test_outer_in_iter_bad_input(bad_graph, expected_exception):
     with pytest.raises(expected_exception):
-        next(tasks.outer_in_iter(bad_graph))
+        next(m.outer_in_iter(bad_graph))
 
 
 outer_in_iter_testcases = {
-    "one_node_no_edges": (
-        tasks.nx.trivial_graph(create_using=tasks.nx.DiGraph),
-        [set([0])],
-    ),
+    "one_node_no_edges": (m.nx.trivial_graph(create_using=m.nx.DiGraph), [set([0])],),
     "five_node_path_graph": (
-        tasks.nx.path_graph(5, create_using=tasks.nx.DiGraph),
+        m.nx.path_graph(5, create_using=m.nx.DiGraph),
         [set([i]) for i in range(4, -1, -1)],
     ),
     "small_tree": (
-        tasks.nx.DiGraph([(0, 1), (1, 2), (1, 3), (1, 4), (2, 4)]),
+        m.nx.DiGraph([(0, 1), (1, 2), (1, 3), (1, 4), (2, 4)]),
         [set([3, 4]), set([2]), set([1]), set([0])],
     ),
 }
@@ -47,7 +46,7 @@ outer_in_iter_testcases = {
     ids=outer_in_iter_testcases.keys(),
 )
 def test_outer_in_iter(graph, expected_nodes):
-    nodes = list(tasks.outer_in_iter(graph))
+    nodes = list(m.outer_in_iter(graph))
     # visits all nodes
     assert set(graph.nodes()) == set().union(*nodes)
 
@@ -72,7 +71,7 @@ def test_outer_in_iter(graph, expected_nodes):
 
 
 outer_in_graph_iter_failing_testcases = {
-    "no_nodes_no_edges": tasks.nx.empty_graph(n=0, create_using=tasks.nx.DiGraph),
+    "no_nodes_no_edges": m.nx.empty_graph(n=0, create_using=m.nx.DiGraph),
 }
 
 
@@ -83,23 +82,23 @@ outer_in_graph_iter_failing_testcases = {
 )
 def test_outer_in_graph_iter_bad_input(bad_graph, expected_exception):
     with pytest.raises(expected_exception):
-        next(tasks.outer_in_graph_iter(bad_graph))
+        next(m.outer_in_graph_iter(bad_graph))
 
 
 graph_iter_testcases = {
     **outer_in_iter_testcases,
-    "two_node_loop": (tasks.nx.DiGraph([(0, 1), (1, 0)]), [set([0, 1])],),
-    "three_node_loop": (tasks.nx.DiGraph([(0, 1), (1, 2), (2, 0)]), [set([0, 1, 2])],),
+    "two_node_loop": (m.nx.DiGraph([(0, 1), (1, 0)]), [set([0, 1])],),
+    "three_node_loop": (m.nx.DiGraph([(0, 1), (1, 2), (2, 0)]), [set([0, 1, 2])],),
     "path_to_three_node_loop": (
-        tasks.nx.DiGraph([(4, 3), (3, 2), (0, 1), (1, 2), (2, 0),]),
+        m.nx.DiGraph([(4, 3), (3, 2), (0, 1), (1, 2), (2, 0),]),
         [set([0, 1, 2]), set([3]), set([4]),],
     ),
     "two_two_node_loops": (
-        tasks.nx.DiGraph([(0, 1), (1, 0), (0, 2), (2, 0)]),
+        m.nx.DiGraph([(0, 1), (1, 0), (0, 2), (2, 0)]),
         [set([0, 1, 2])],
     ),
     "nested_three_and_two_node_loops": (
-        tasks.nx.DiGraph([(0, 1), (1, 2), (2, 0), (0, 1), (1, 0), (0, 2), (2, 0)],),
+        m.nx.DiGraph([(0, 1), (1, 2), (2, 0), (0, 1), (1, 0), (0, 2), (2, 0)],),
         [set([0, 1, 2])],
     ),
 }
@@ -111,7 +110,7 @@ graph_iter_testcases = {
     ids=graph_iter_testcases.keys(),
 )
 def test_outer_in_graph_iter(graph, expected_nodes):
-    nodes = list(tasks.outer_in_graph_iter(graph))
+    nodes = list(m.outer_in_graph_iter(graph))
     # visits all nodes
     assert set(graph.nodes()) == set().union(*nodes)
 

--- a/tests/worker/test_outer_in_iter.py
+++ b/tests/worker/test_outer_in_iter.py
@@ -4,8 +4,8 @@ import depobs.worker.tasks as tasks
 
 
 outer_in_iter_failing_testcases = {
-    "null_graph": tasks.nx.empty_graph(n=0, create_using=tasks.nx.DiGraph),
-    "self_loop": tasks.nx.DiGraph([(0, 0)]),
+    "no_nodes_no_edges": tasks.nx.empty_graph(n=0, create_using=tasks.nx.DiGraph),
+    "self_loop": (tasks.nx.DiGraph([(0, 0)]), [set([0])],),
     "two_node_loop": tasks.nx.DiGraph([(0, 1), (1, 0)]),
     "three_node_loop": tasks.nx.DiGraph([(0, 1), (1, 2), (2, 0)]),
     "two_two_node_loops": tasks.nx.DiGraph([(0, 1), (1, 0), (0, 2), (2, 0)]),
@@ -26,6 +26,10 @@ def test_outer_in_iter_bad_input(bad_graph, expected_exception):
 
 
 outer_in_iter_testcases = {
+    "one_node_no_edges": (
+        tasks.nx.trivial_graph(create_using=tasks.nx.DiGraph),
+        [set([0])],
+    ),
     "five_node_path_graph": (
         tasks.nx.path_graph(5, create_using=tasks.nx.DiGraph),
         [set([i]) for i in range(4, -1, -1)],
@@ -60,6 +64,72 @@ def test_outer_in_iter(graph, expected_nodes):
     for node_set in nodes:
         for node in node_set:
             assert all(dst in visited for (_, dst) in graph.out_edges(node))
+        visited |= node_set
+
+    # returns expected values
+    assert nodes == expected_nodes
+    assert len(nodes) == len(expected_nodes)
+
+
+outer_in_graph_iter_failing_testcases = {
+    "no_nodes_no_edges": tasks.nx.empty_graph(n=0, create_using=tasks.nx.DiGraph),
+}
+
+
+@pytest.mark.parametrize(
+    "bad_graph, expected_exception",
+    [(g, Exception) for g in outer_in_graph_iter_failing_testcases.values()],
+    ids=outer_in_graph_iter_failing_testcases.keys(),
+)
+def test_outer_in_graph_iter_bad_input(bad_graph, expected_exception):
+    with pytest.raises(expected_exception):
+        next(tasks.outer_in_graph_iter(bad_graph))
+
+
+graph_iter_testcases = {
+    **outer_in_iter_testcases,
+    "two_node_loop": (tasks.nx.DiGraph([(0, 1), (1, 0)]), [set([0, 1])],),
+    "three_node_loop": (tasks.nx.DiGraph([(0, 1), (1, 2), (2, 0)]), [set([0, 1, 2])],),
+    "path_to_three_node_loop": (
+        tasks.nx.DiGraph([(4, 3), (3, 2), (0, 1), (1, 2), (2, 0),]),
+        [set([0, 1, 2]), set([3]), set([4]),],
+    ),
+    "two_two_node_loops": (
+        tasks.nx.DiGraph([(0, 1), (1, 0), (0, 2), (2, 0)]),
+        [set([0, 1, 2])],
+    ),
+    "nested_three_and_two_node_loops": (
+        tasks.nx.DiGraph([(0, 1), (1, 2), (2, 0), (0, 1), (1, 0), (0, 2), (2, 0)],),
+        [set([0, 1, 2])],
+    ),
+}
+
+
+@pytest.mark.parametrize(
+    "graph, expected_nodes",
+    graph_iter_testcases.values(),
+    ids=graph_iter_testcases.keys(),
+)
+def test_outer_in_graph_iter(graph, expected_nodes):
+    nodes = list(tasks.outer_in_graph_iter(graph))
+    # visits all nodes
+    assert set(graph.nodes()) == set().union(*nodes)
+
+    # visits each node once
+    for node_set in nodes:
+        assert all(
+            node_set.isdisjoint(other_node_set)
+            for other_node_set in nodes
+            if other_node_set != node_set
+        )
+
+    # only visits node when its deps were already visited or in the set to score
+    visited = set()
+    for node_set in nodes:
+        for node in node_set:
+            assert all(
+                dst in (visited | node_set) for (_, dst) in graph.out_edges(node)
+            )
         visited |= node_set
 
     # returns expected values

--- a/tests/worker/test_scoring.py
+++ b/tests/worker/test_scoring.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+import depobs.worker.scoring as m
+
+
+def test_score_package(mocker):
+    # https://docs.python.org/3/library/unittest.mock.html#where-to-patch
+    dt_mock = mocker.patch("depobs.worker.scoring.datetime")
+
+    npmsio_score_mock = mocker.patch("depobs.worker.scoring.get_npms_io_score")
+    mocker.patch("depobs.worker.scoring.get_npm_registry_data")
+    mocker.patch("depobs.worker.scoring.get_vulnerability_counts")
+    scored: m.PackageReport = m.score_package(
+        package_name="foo",
+        package_version="0.0.0",
+        direct_dep_reports=[],  # List[PackageReport]
+        all_deps_count=0,
+    )
+    assert (
+        scored.json_with_dependencies()
+        == m.PackageReport(
+            npmsio_score=npmsio_score_mock().first(),
+            scoring_date=dt_mock.now(),
+            package="foo",
+            version="0.0.0",
+            directVulnsCritical_score=0,
+            directVulnsHigh_score=0,
+            directVulnsMedium_score=0,
+            directVulnsLow_score=0,
+            all_deps=0,
+            immediate_deps=0,
+            indirectVulnsCritical_score=0,
+            indirectVulnsHigh_score=0,
+            indirectVulnsMedium_score=0,
+            indirectVulnsLow_score=0,
+            status="scanned",
+        ).json_with_dependencies()
+    )
+
+
+def test_score_package_and_children():
+    pass

--- a/tests/worker/test_scoring.py
+++ b/tests/worker/test_scoring.py
@@ -1,43 +1,319 @@
 # -*- coding: utf-8 -*-
 
+from typing import Any, Dict, Iterator, List, Optional, Tuple
+
 import pytest
 
 import depobs.worker.scoring as m
 
 
-def test_score_package(mocker):
+score_package_testcases = {
+    "zero_npmsio_score": (
+        [],
+        [],
+        0,
+        [],
+        {
+            "all_deps": 0,
+            "authors": None,
+            "contributors": None,
+            "dependencies": [],
+            "directVulnsCritical_score": 0,
+            "directVulnsHigh_score": 0,
+            "directVulnsLow_score": 0,
+            "directVulnsMedium_score": 0,
+            "id": None,
+            "immediate_deps": 0,
+            "indirectVulnsCritical_score": 0,
+            "indirectVulnsHigh_score": 0,
+            "indirectVulnsLow_score": 0,
+            "indirectVulnsMedium_score": 0,
+            "npmsio_score": 0,
+            "package": "foo",
+            "release_date": None,
+            "status": "scanned",
+            "task_id": None,
+            "task_status": None,
+            "top_score": None,
+            "version": "0.0.0",
+        },
+    ),
+    "nonzero_npmsio_score": (
+        [],
+        [],
+        0.53,
+        [],
+        {
+            "all_deps": 0,
+            "authors": None,
+            "contributors": None,
+            "dependencies": [],
+            "directVulnsCritical_score": 0,
+            "directVulnsHigh_score": 0,
+            "directVulnsLow_score": 0,
+            "directVulnsMedium_score": 0,
+            "id": None,
+            "immediate_deps": 0,
+            "indirectVulnsCritical_score": 0,
+            "indirectVulnsHigh_score": 0,
+            "indirectVulnsLow_score": 0,
+            "indirectVulnsMedium_score": 0,
+            "npmsio_score": 0.53,
+            "package": "foo",
+            "release_date": None,
+            "status": "scanned",
+            "task_id": None,
+            "task_status": None,
+            "top_score": None,
+            "version": "0.0.0",
+        },
+    ),
+    "nonzero_npmsio_score_direct_vulns": (
+        [
+            # TODO: confirm get_vulnerability_counts doesn't return "medium" and "moderate" severities
+            (None, None, "critical", 1),
+            (None, None, "high", 1),
+            (None, None, "medium", 1),
+            (None, None, "moderate", 1),
+            (None, None, "low", 1),
+            (None, None, "unexpected", 1),
+        ],
+        [],
+        0.53,
+        [],
+        {
+            "all_deps": 0,
+            "authors": None,
+            "contributors": None,
+            "dependencies": [],
+            "directVulnsCritical_score": 1,
+            "directVulnsHigh_score": 1,
+            "directVulnsLow_score": 1,
+            "directVulnsMedium_score": 1,
+            "id": None,
+            "immediate_deps": 0,
+            "indirectVulnsCritical_score": 0,
+            "indirectVulnsHigh_score": 0,
+            "indirectVulnsLow_score": 0,
+            "indirectVulnsMedium_score": 0,
+            "npmsio_score": 0.53,
+            "package": "foo",
+            "release_date": None,
+            "status": "scanned",
+            "task_id": None,
+            "task_status": None,
+            "top_score": None,
+            "version": "0.0.0",
+        },
+    ),
+    "nonzero_npmsio_score_null_npm_reg_data": (
+        [],
+        [(None, None, None)],
+        0.53,
+        [],
+        {
+            "all_deps": 0,
+            "authors": 0,
+            "contributors": 0,
+            "dependencies": [],
+            "directVulnsCritical_score": 0,
+            "directVulnsHigh_score": 0,
+            "directVulnsLow_score": 0,
+            "directVulnsMedium_score": 0,
+            "id": None,
+            "immediate_deps": 0,
+            "indirectVulnsCritical_score": 0,
+            "indirectVulnsHigh_score": 0,
+            "indirectVulnsLow_score": 0,
+            "indirectVulnsMedium_score": 0,
+            "npmsio_score": 0.53,
+            "package": "foo",
+            "release_date": None,
+            "status": "scanned",
+            "task_id": None,
+            "task_status": None,
+            "top_score": None,
+            "version": "0.0.0",
+        },
+    ),
+    "nonzero_npmsio_score_npm_reg_data": (
+        [],
+        [
+            (
+                "release day!",
+                ["author1@example.com"],
+                ["contributor1@example.com", "contributor2@example.com"],
+            )
+        ],
+        0.53,
+        [],
+        {
+            "all_deps": 0,
+            "authors": 1,
+            "contributors": 2,
+            "dependencies": [],
+            "directVulnsCritical_score": 0,
+            "directVulnsHigh_score": 0,
+            "directVulnsLow_score": 0,
+            "directVulnsMedium_score": 0,
+            "id": None,
+            "immediate_deps": 0,
+            "indirectVulnsCritical_score": 0,
+            "indirectVulnsHigh_score": 0,
+            "indirectVulnsLow_score": 0,
+            "indirectVulnsMedium_score": 0,
+            "npmsio_score": 0.53,
+            "package": "foo",
+            "release_date": "release day!",
+            "status": "scanned",
+            "task_id": None,
+            "task_status": None,
+            "top_score": None,
+            "version": "0.0.0",
+        },
+    ),
+    "nonzero_npmsio_score_direct_dep_reports": (
+        [],
+        [
+            (
+                "release day!",
+                ["author1@example.com"],
+                ["contributor1@example.com", "contributor2@example.com"],
+            )
+        ],
+        0.53,
+        [
+            m.PackageReport(
+                directVulnsCritical_score=None,
+                directVulnsHigh_score=None,
+                directVulnsMedium_score=None,
+                directVulnsLow_score=None,
+                indirectVulnsCritical_score=None,
+                indirectVulnsHigh_score=None,
+                indirectVulnsMedium_score=None,
+                indirectVulnsLow_score=None,
+            ),
+            m.PackageReport(
+                directVulnsCritical_score=2,
+                directVulnsHigh_score=None,
+                directVulnsMedium_score=None,
+                directVulnsLow_score=None,
+                indirectVulnsCritical_score=None,
+                indirectVulnsHigh_score=1,
+                indirectVulnsMedium_score=None,
+                indirectVulnsLow_score=None,
+            ),
+            m.PackageReport(
+                directVulnsCritical_score=1,
+                directVulnsHigh_score=None,
+                directVulnsMedium_score=None,
+                directVulnsLow_score=None,
+                indirectVulnsCritical_score=None,
+                indirectVulnsHigh_score=1,
+                indirectVulnsMedium_score=1,
+                indirectVulnsLow_score=1,
+            ),
+        ],
+        {
+            "all_deps": 0,
+            "authors": 1,
+            "contributors": 2,
+            "dependencies": [
+                m.PackageReport(
+                    directVulnsCritical_score=None,
+                    directVulnsHigh_score=None,
+                    directVulnsMedium_score=None,
+                    directVulnsLow_score=None,
+                    indirectVulnsCritical_score=None,
+                    indirectVulnsHigh_score=None,
+                    indirectVulnsMedium_score=None,
+                    indirectVulnsLow_score=None,
+                ).json_with_dependencies(depth=0),
+                m.PackageReport(
+                    directVulnsCritical_score=2,
+                    directVulnsHigh_score=None,
+                    directVulnsMedium_score=None,
+                    directVulnsLow_score=None,
+                    indirectVulnsCritical_score=None,
+                    indirectVulnsHigh_score=1,
+                    indirectVulnsMedium_score=None,
+                    indirectVulnsLow_score=None,
+                ).json_with_dependencies(depth=0),
+                m.PackageReport(
+                    directVulnsCritical_score=1,
+                    directVulnsHigh_score=None,
+                    directVulnsMedium_score=None,
+                    directVulnsLow_score=None,
+                    indirectVulnsCritical_score=None,
+                    indirectVulnsHigh_score=1,
+                    indirectVulnsMedium_score=1,
+                    indirectVulnsLow_score=1,
+                ).json_with_dependencies(depth=0),
+            ],
+            "directVulnsCritical_score": 0,
+            "directVulnsHigh_score": 0,
+            "directVulnsLow_score": 0,
+            "directVulnsMedium_score": 0,
+            "id": None,
+            "immediate_deps": 3,
+            "indirectVulnsCritical_score": 3,
+            "indirectVulnsHigh_score": 2,
+            "indirectVulnsLow_score": 1,
+            "indirectVulnsMedium_score": 1,
+            "npmsio_score": 0.53,
+            "package": "foo",
+            "release_date": "release day!",
+            "status": "scanned",
+            "task_id": None,
+            "task_status": None,
+            "top_score": None,
+            "version": "0.0.0",
+        },
+    ),
+}
+
+
+@pytest.mark.parametrize(
+    "vulns, npm_registry_data, npmsio_score, direct_dep_reports, expected_package_report_with_deps_json",
+    score_package_testcases.values(),
+    ids=score_package_testcases.keys(),
+)
+def test_score_package(
+    mocker,
+    vulns: Iterator[
+        Tuple[str, str, str, int]
+    ],  # generates: package (name), version, severity, count
+    npm_registry_data: Iterator[
+        Tuple[Any, List[str], List[str]]
+    ],  # generates: published_at, maintainers, contributors
+    npmsio_score: Optional[int],
+    direct_dep_reports: List[m.PackageReport],
+    expected_package_report_with_deps_json: Dict[str, Any],
+):
     # https://docs.python.org/3/library/unittest.mock.html#where-to-patch
     dt_mock = mocker.patch("depobs.worker.scoring.datetime")
+    expected_package_report_with_deps_json["scoring_date"] = dt_mock.now()
 
-    npmsio_score_mock = mocker.patch("depobs.worker.scoring.get_npms_io_score")
-    mocker.patch("depobs.worker.scoring.get_npm_registry_data")
-    mocker.patch("depobs.worker.scoring.get_vulnerability_counts")
+    npmsio_score_mock = mocker.patch(
+        "depobs.worker.scoring.get_npms_io_score",
+        **{"return_value.first.return_value": npmsio_score},
+    )
+    mocker.patch(
+        "depobs.worker.scoring.get_npm_registry_data", return_value=npm_registry_data
+    )
+    mocker.patch("depobs.worker.scoring.get_vulnerability_counts", return_value=vulns)
+
     scored: m.PackageReport = m.score_package(
         package_name="foo",
         package_version="0.0.0",
-        direct_dep_reports=[],  # List[PackageReport]
+        direct_dep_reports=direct_dep_reports,
         all_deps_count=0,
     )
-    assert (
-        scored.json_with_dependencies()
-        == m.PackageReport(
-            npmsio_score=npmsio_score_mock().first(),
-            scoring_date=dt_mock.now(),
-            package="foo",
-            version="0.0.0",
-            directVulnsCritical_score=0,
-            directVulnsHigh_score=0,
-            directVulnsMedium_score=0,
-            directVulnsLow_score=0,
-            all_deps=0,
-            immediate_deps=0,
-            indirectVulnsCritical_score=0,
-            indirectVulnsHigh_score=0,
-            indirectVulnsMedium_score=0,
-            indirectVulnsLow_score=0,
-            status="scanned",
-        ).json_with_dependencies()
+    assert scored
+    assert len(scored.dependencies) == len(
+        expected_package_report_with_deps_json["dependencies"]
     )
+    assert scored.json_with_dependencies() == expected_package_report_with_deps_json
 
 
 def test_score_package_and_children():

--- a/util/run_tests_with_coverage.sh
+++ b/util/run_tests_with_coverage.sh
@@ -7,6 +7,7 @@ if [[ "$CI" = "" ]]; then
     docker-compose exec api coverage run -m pytest "$@"
     docker-compose exec api coverage report
     docker-compose exec api coverage html
+    rm -rf htmlcov/
     docker cp dependency-observatory-api:/tmp/htmlcov/ "$(pwd)/htmlcov/"
     python -m webbrowser -t htmlcov/index.html
 else


### PR DESCRIPTION
Changes for #141:

* move scoring to `worker.scoring`
* move DAG iter alg to `scanner.graph_traversal` and add a graph iter alg
* add `pytest-mock` to requirements
* add unit tests for `score_package`
* remove some unused / unreachable code from `score_package`
* fix util run pkg with coverage showing old reports