### PR TITLE
Fix 234 improve package not found errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,6 @@ running: celery -A depobs.worker.tasks call depobs.worker.tasks.add --args [2,2]
 [tasks]
   . depobs.worker.tasks.add
   . depobs.worker.tasks.build_report_tree
-  . depobs.worker.tasks.check_npm_package_exists
   . depobs.worker.tasks.check_package_in_npm_registry
   . depobs.worker.tasks.check_package_name_in_npmsio
   . depobs.worker.tasks.scan_npm_package

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ running: celery -A depobs.worker.tasks call depobs.worker.tasks.add --args [2,2]
 [tasks]
   . depobs.worker.tasks.add
   . depobs.worker.tasks.build_report_tree
-  . depobs.worker.tasks.check_package_in_npm_registry
+  . depobs.worker.tasks.fetch_package_entry_from_registry
   . depobs.worker.tasks.check_package_name_in_npmsio
   . depobs.worker.tasks.scan_npm_package
   . depobs.worker.tasks.scan_npm_package_then_build_report_tree

--- a/depobs/website/config.py
+++ b/depobs/website/config.py
@@ -23,6 +23,8 @@ LOGGING = {
         "do": {"handlers": ["console"], "level": "DEBUG"},
         "request.summary": {"handlers": ["console"], "level": "INFO"},
         "depobs.database.models": {"handlers": ["console"], "level": "INFO"},
+        "depobs.website.views": {"handlers": ["console"], "level": "INFO"},
+        "depobs.website.scans": {"handlers": ["console"], "level": "INFO"},
         "depobs.worker.tasks": {"handlers": ["console"], "level": "INFO"},
         "depobs.worker.scoring": {"handlers": ["console"], "level": "INFO",},
         "depobs.scanner.clients.cratesio": {"handlers": ["console"], "level": "INFO"},

--- a/depobs/website/scans.py
+++ b/depobs/website/scans.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+import logging
 from typing import Tuple
 
 from flask import Blueprint, jsonify, make_response, request
@@ -6,6 +7,8 @@ from werkzeug.exceptions import BadRequest
 
 from depobs.website.celery_tasks import get_celery_tasks
 import depobs.worker.validators as validators
+
+log = logging.getLogger(__name__)
 
 scans_blueprint = api = Blueprint("scans_blueprint", __name__)
 

--- a/depobs/website/static/do.js
+++ b/depobs/website/static/do.js
@@ -7,7 +7,11 @@ function getLinkURL(name, version) {
 }
 
 function getPrefixedURL(prefix, name, version) {
-    return prefix + '?package_name=' + encodeURIComponent(name) + '&package_version=' + encodeURIComponent(version);
+    let url = prefix + '?package_name=' + encodeURIComponent(name);
+    if (version !== null) {
+	url = url  + '&package_version=' + encodeURIComponent(version);
+    }
+    return url;
 }
 
 window.onload = function() {

--- a/depobs/website/static/do.js
+++ b/depobs/website/static/do.js
@@ -39,6 +39,9 @@ function getPackageInfo(pkg, ver) {
                 document.getElementById('scan-started').className = "d-none";
                 document.getElementById('no-package').className = "";
                 document.getElementById('no-scan').className = "";
+                response.json().then(function(jsonError) {
+                    document.getElementById('no-package-error').innerText = jsonError.description;
+                });
             } else {
                 document.getElementById('scan-started').className = "d-none";
                 document.getElementById('no-package').className = "";

--- a/depobs/website/views.py
+++ b/depobs/website/views.py
@@ -86,7 +86,7 @@ def handle_package_report_not_found(e):
     if npm_registry_entry is None:
         return (
             dict(
-                description=f"{e.description} Unable to find package {package_name} on the npm registry."
+                description=f"Unable to find package named {package_name!r} on the npm registry."
             ),
             404,
         )
@@ -103,8 +103,8 @@ def handle_package_report_not_found(e):
         )
         return (
             dict(
-                description=f"{e.description} Unable to find version "
-                f"{package_version} of package {package_name} on the npm registry."
+                description=f"Unable to find version "
+                f"{package_version!r} of package {package_name!r} on the npm registry."
             ),
             404,
         )
@@ -135,8 +135,8 @@ def handle_package_report_not_found(e):
         if not len(package_reports):
             return (
                 dict(
-                    description=f"{e.description} Unable to find any versions "
-                    f"of package {package_name} on the npm registry."
+                    description=f"Unable to find any versions "
+                    f"of package {package_name!r} on the npm registry."
                 ),
                 404,
             )

--- a/depobs/website/views.py
+++ b/depobs/website/views.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import logging
 from typing import Dict, Optional
 
 from flask import abort, Blueprint, Response, request, send_from_directory
@@ -11,6 +12,8 @@ from depobs.website.scans import (
     validate_scored_after_ts_query_param,
 )
 from depobs.website.celery_tasks import get_celery_tasks
+
+log = logging.getLogger(__name__)
 
 STANDARD_HEADERS = {"Access-Control-Allow-Origin": "*"}
 
@@ -75,10 +78,33 @@ def handle_package_report_not_found(e):
             return package_report.report_json, 500
         return package_report.report_json, 202
 
-    if not get_celery_tasks().check_npm_package_exists(package_name, package_version):
+    npm_registry_entry: Optional[
+        Dict
+    ] = get_celery_tasks().fetch_package_entry_from_registry(
+        package_name, package_version
+    )
+    if npm_registry_entry is None:
         return (
             dict(
-                description=f"{e.description} Unable to find package on npm registry and npms.io."
+                description=f"{e.description} Unable to find package {package_name} on the npm registry."
+            ),
+            404,
+        )
+
+    package_versions_on_registry: Dict = npm_registry_entry.get("versions", {})
+
+    # if a scan of a specific package version was requested check that it exists
+    if package_version is not None:
+        package_version_exists = package_versions_on_registry.get(
+            package_version, False
+        )
+        log.info(
+            f"package: {package_name}@{package_version!r} on npm registry? {package_version_exists}"
+        )
+        return (
+            dict(
+                description=f"{e.description} Unable to find version "
+                f"{package_version} of package {package_name} on the npm registry."
             ),
             404,
         )
@@ -88,10 +114,35 @@ def handle_package_report_not_found(e):
         package_name, package_version
     )
 
-    # NB: use transaction concurrent calls e.g. another query inserts after select
-    package_report = models.insert_package_report_placeholder_or_update_task_id(
-        package_name, package_version, result.id
-    )
+    # TODO: make sure concurrent API calls don't introduce a data race
+    if package_version is not None:
+        package_report = models.insert_package_report_placeholder_or_update_task_id(
+            package_name, package_version, result.id
+        )
+    else:
+        # a version wasn't specified, so scan_npm_package will scan all versions
+        # update or insert placeholders for all the versions referencing the same scan task
+        package_reports = [
+            models.insert_package_report_placeholder_or_update_task_id(
+                package_name, reg_package_version, result.id
+            )
+            for reg_package_version in sorted(package_versions_on_registry.keys())
+        ]
+        log.info(
+            f"inserted placeholder PackageReports for {package_name} at versions {[(pr.id, pr.version) for pr in package_reports]}"
+        )
+
+        if not len(package_reports):
+            return (
+                dict(
+                    description=f"{e.description} Unable to find any versions "
+                    f"of package {package_name} on the npm registry."
+                ),
+                404,
+            )
+        # return the report for the alphabetically highest version number (likely most recently published package)
+        package_report = package_reports[-1]
+
     return package_report.report_json, 202
 
 

--- a/depobs/website/views.py
+++ b/depobs/website/views.py
@@ -41,7 +41,7 @@ class PackageReportNotFound(NotFound):
         if self.package_version is not None:
             msg += f"@{self.package_version}"
         if self.scored_after is not None:
-            msg += f"scored after {self.scored_after}"
+            msg += f" scored after {self.scored_after}"
         return msg + " not found."
 
 

--- a/depobs/worker/tasks.py
+++ b/depobs/worker/tasks.py
@@ -348,25 +348,13 @@ def check_package_in_npm_registry(
     return package_name_exists
 
 
-@app.task()
-def check_npm_package_exists(
-    package_name: str, package_version: Optional[str] = None
-) -> bool:
-    """
-    Check that an npm package name has a score on npms.io and is published on
-    the npm registry if a version is provided check that it's in the npm registry
-    """
-    # check npms.io first because it's usually faster (smaller response sizes)
-    return check_package_name_in_npmsio(package_name) and check_package_in_npm_registry(
-        package_name, package_version
-    )
+    return npm_registry_entry
 
 
 # list tasks for the web server to register against its flask app
 tasks = [
     add,
     build_report_tree,
-    check_npm_package_exists,
     check_package_in_npm_registry,
     check_package_name_in_npmsio,
     scan_npm_package,


### PR DESCRIPTION
fixes: #234 removes the npms.io check and updates the UI to show the description field for 404 errors 

Functional Tests:

- [x] no version adds placeholders for all versions and scans all versions http://localhost:8000/?manager=npm&package=%40hapi%2Fbounce
- [x] invalid package name returns 404 with message to that effect http://localhost:8000/?manager=npm&package=%40hapi%2Fbou
- [x] invalid package version returns 404 with message to that effect http://localhost:8000/?manager=npm&package=%40hapi%2Fbounce&version=0.0.0