### PR TITLE
refactor scoring

### DIFF
--- a/depobs/database/models.py
+++ b/depobs/database/models.py
@@ -752,6 +752,16 @@ def get_graph_links(graph: PackageGraph) -> List[PackageLink]:
     )
 
 
+def get_package_from_name_and_version(
+    name: str, version: str
+) -> Optional[PackageVersion]:
+    return (
+        db.session.query(PackageVersion)
+        .filter_by(name=name, version=version)
+        .one_or_none()
+    )
+
+
 def get_package_from_id(id: int) -> Optional[PackageVersion]:
     package_version = (
         db.session.query(PackageVersion).filter(PackageVersion.id == id).one_or_none()

--- a/depobs/database/models.py
+++ b/depobs/database/models.py
@@ -1082,3 +1082,20 @@ def create_tables_and_views(app: flask.app.Flask) -> None:
             ],
         )
         create_views(db.engine)
+
+
+def get_advisories_by_package_versions(
+    package_versions: List[PackageVersion],
+) -> List[Advisory]:
+    """
+    Returns all advisories that directly impact the provided PackageVersion objects.
+    """
+    return (
+        db.session.query(Advisory)
+        .filter(
+            Advisory.vulnerable_package_version_ids.contains(
+                [package_version.id for package_version in package_versions]
+            )
+        )
+        .all()
+    )

--- a/depobs/website/scans.py
+++ b/depobs/website/scans.py
@@ -94,12 +94,3 @@ def scan_npm_package_then_build_report_tree():
         package_name, package_version
     )
     return dict(task_id=result.id)
-
-
-@api.route("/score", methods=["POST"])
-def score():
-    package_name, package_version, _ = validate_npm_package_version_query_params()
-    result: celery.result.AsyncResult = get_celery_tasks().score_package.delay(
-        package_name, package_version
-    )
-    return dict(task_id=result.id)

--- a/depobs/worker/scoring.py
+++ b/depobs/worker/scoring.py
@@ -99,7 +99,8 @@ def score_package(
             setattr(
                 pr, f"indirectVulns{severity}_score", current_count + dep_vuln_count,
             )
-        pr.dependencies.append(report)
+
+    pr.dependencies.extend(direct_dep_reports)
     return pr
 
 

--- a/depobs/worker/tasks.py
+++ b/depobs/worker/tasks.py
@@ -76,8 +76,6 @@ log = get_task_logger(__name__)
 
 app = create_celery_app()
 
-score_package = app.task(score_package)
-
 
 @app.task()
 def add(x, y):
@@ -345,5 +343,4 @@ tasks = [
     check_package_name_in_npmsio,
     scan_npm_package,
     scan_npm_package_then_build_report_tree,
-    score_package,
 ]

--- a/tests/worker/test_scoring.py
+++ b/tests/worker/test_scoring.py
@@ -384,3 +384,56 @@ def test_score_package_and_children(
         reports, expected_package_reports_with_deps_json
     ):
         assert report.json_with_dependencies() == expected_report_json
+
+
+count_advisories_by_severity_testcases = {
+    "none": ([], m.Counter()),
+    "empty_str_ignored": ([m.Advisory(severity=""),], m.Counter(),),
+    "none_ignored": ([m.Advisory(severity=None),], m.Counter(),),
+    "one_critical_upper_case_counted": (
+        [m.Advisory(severity="CRITICAL")],
+        m.Counter({m.AdvisorySeverity.CRITICAL: 1}),
+    ),
+    "one_critical_mixed_case_counted": (
+        [m.Advisory(severity="cRitiCal")],
+        m.Counter({m.AdvisorySeverity.CRITICAL: 1}),
+    ),
+    "one_medium_one_moderate_counted": (
+        [m.Advisory(severity="medium"), m.Advisory(severity="moderate")],
+        m.Counter({m.AdvisorySeverity.MEDIUM: 2}),
+    ),
+    "one_critical_counted": (
+        [m.Advisory(severity="critical")],
+        m.Counter({m.AdvisorySeverity.CRITICAL: 1}),
+    ),
+    "two_critical_counted": (
+        [m.Advisory(severity="critical"), m.Advisory(severity="critical")],
+        m.Counter({m.AdvisorySeverity.CRITICAL: 2}),
+    ),
+    "two_critical_one_high_counted": (
+        [
+            m.Advisory(severity="critical"),
+            m.Advisory(severity="critical"),
+            m.Advisory(severity="high"),
+        ],
+        m.Counter({m.AdvisorySeverity.CRITICAL: 2, m.AdvisorySeverity.HIGH: 1}),
+    ),
+}
+
+
+@pytest.mark.parametrize(
+    "advisories, expected_counter",
+    count_advisories_by_severity_testcases.values(),
+    ids=count_advisories_by_severity_testcases.keys(),
+)
+def test_count_advisories_by_severity(
+    advisories: List[m.Advisory], expected_counter: m.Counter
+):
+    assert m.count_advisories_by_severity(advisories) == expected_counter
+
+
+def test_zeroed_severity_counter():
+    zeroed = m.zeroed_severity_counter()
+    for severity in m.AdvisorySeverity:
+        assert zeroed[severity] == 0
+    assert len(zeroed) == len(m.AdvisorySeverity)


### PR DESCRIPTION
Changes:

* remove the `POST /score` endpoint
* fetch and count direct vulns using `database.models.Advisory` aggregated in `collections.Counter`s