### PR TITLE
db: don't error for multiple rows of npm reg or score data per packag…

### DIFF
--- a/depobs/database/models.py
+++ b/depobs/database/models.py
@@ -305,7 +305,7 @@ class PackageGraph(db.Model):
         return {
             package_version.id: get_npm_registry_data(
                 package_version.name, package_version.version
-            ).one_or_none()
+            ).first()
             for package_version in self.distinct_package_versions_by_id.values()
         }
 
@@ -317,7 +317,7 @@ class PackageGraph(db.Model):
         tmp = {
             package_version.id: get_npms_io_score(
                 package_version.name, package_version.version
-            ).one_or_none()
+            ).first()
             for package_version in self.distinct_package_versions_by_id.values()
         }
         return {


### PR DESCRIPTION
…e version

`.one_or_none()` throws for multiple rows and we might have multiple rows of npms.io scores or npm reg data per package version.

e.g.

```python
[2020-05-06 16:38:26,115: ERROR/ForkPoolWorker-1] Task depobs.worker.tasks.build_report_tree[4b27513b-a7cf-4e42-a1c8-67b3cdec722b] raised unexpected: MultipleResultsFound('Multiple rows were found for one_or_none()')
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/celery/app/trace.py", line 385, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/app/depobs/website/do.py", line 85, in __call__
    return self.run(*args, **kwargs)
  File "/app/depobs/worker/tasks.py", line 274, in build_report_tree
    store_package_reports(scoring.score_package_graph(db_graph))
  File "/app/depobs/worker/scoring.py", line 356, in score_package_graph
    g: nx.DiGraph = add_scoring_component_data_to_node_attrs(
  File "/app/depobs/worker/scoring.py", line 324, in add_scoring_component_data_to_node_attrs
    **{
  File "/app/depobs/worker/scoring.py", line 325, in <dictcomp>
    component.graph_node_attr_name: component.data_by_package_version_id(
  File "/app/depobs/worker/scoring.py", line 141, in data_by_package_version_id
    return db_graph.get_npmsio_scores_by_package_version_id()
  File "/app/depobs/database/models.py", line 317, in get_npmsio_scores_by_package_version_id
    tmp = {
  File "/app/depobs/database/models.py", line 318, in <dictcomp>
    package_version.id: get_npms_io_score(
  File "/usr/local/lib/python3.8/site-packages/sqlalchemy/orm/query.py", line 3337, in one_or_none
    raise orm_exc.MultipleResultsFound(
sqlalchemy.orm.exc.MultipleResultsFound: Multiple rows were found for one_or_none()
``` 