### PR TITLE
Fix 162 argparse namespaces

### DIFF
--- a/depobs/scanner/clients/aiohttp_client_config.py
+++ b/depobs/scanner/clients/aiohttp_client_config.py
@@ -1,0 +1,28 @@
+from typing import TypedDict
+
+
+class AIOHTTPClientConfig(TypedDict, total=True):  # require keys defined below
+    """
+    Shared base AIOHTTPClient config.
+    """
+
+    # time to sleep between requests in seconds
+    delay: int
+
+    # don't hit the third part API just print intended actions
+    dry_run: bool
+
+    # number of simultaneous connections to open
+    max_connections: int
+
+    # number of times to retry requests
+    max_retries: int
+
+    # number of packages to fetch in once request (for APIs that support it)
+    package_batch_size: int
+
+    # aiohttp total timeout in seconds
+    total_timeout: int
+
+    # User agent to use to query third party APIs
+    user_agent: str

--- a/depobs/scanner/clients/npm_registry.py
+++ b/depobs/scanner/clients/npm_registry.py
@@ -6,6 +6,7 @@ from typing import Any, AsyncGenerator, Dict, Iterable, Optional, TypedDict
 import logging
 
 from depobs.scanner.clients.aiohttp_client_config import AIOHTTPClientConfig
+from depobs.scanner.models.package_meta_result import Result
 from depobs.scanner.pipelines.util import exc_to_str
 from depobs.util.serialize_util import grouper
 
@@ -80,7 +81,7 @@ async def fetch_npm_registry_metadata(
     config: NPMRegistryClientConfig,
     package_names: Iterable[str],
     total_packages: Optional[int] = None,
-) -> AsyncGenerator[Dict[str, Dict], None]:
+) -> AsyncGenerator[Result[Dict[str, Dict]], None]:
     """
     Fetches npm registry metadata for one or more node package names
     """
@@ -113,3 +114,4 @@ async def fetch_npm_registry_metadata(
                 log.error(
                     f"error fetching group {i} for package names {group}: {err}:\n{exc_to_str()}"
                 )
+                yield err

--- a/depobs/scanner/clients/npm_registry.py
+++ b/depobs/scanner/clients/npm_registry.py
@@ -1,18 +1,26 @@
-import argparse
 import asyncio
 import aiohttp
 import backoff
 import math
-from typing import Any, AsyncGenerator, Dict, Iterable, Optional
+from typing import Any, AsyncGenerator, Dict, Iterable, Optional, TypedDict
 import logging
 
+from depobs.scanner.clients.aiohttp_client_config import AIOHTTPClientConfig
 from depobs.scanner.pipelines.util import exc_to_str
 from depobs.util.serialize_util import grouper
 
 log = logging.getLogger(__name__)
 
 
-def aiohttp_session(args: argparse.Namespace) -> aiohttp.ClientSession:
+class NPMRegistryClientConfig(
+    AIOHTTPClientConfig, total=False
+):  # don't require keys defined below
+
+    # an npm registry access token for fetch_npm_registry_metadata. Defaults NPM_PAT env var. Should be read-only.
+    npm_auth_token: str
+
+
+def aiohttp_session(config: NPMRegistryClientConfig) -> aiohttp.ClientSession:
     # "Accept": "application/json vnd.npm.install-v1+json; q=1.0, # application/json; q=0.8, */*"
     # doesn't include author and maintainer info
 
@@ -27,15 +35,15 @@ def aiohttp_session(args: argparse.Namespace) -> aiohttp.ClientSession:
     # e.g. https://registry.npmjs.com/@hapi/bounce/2.0.8
     #
     # https://replicate.npmjs.com/ (flattened scopes) seems to be busted
-    headers = {"Accept": "application/json", "User-Agent": args.user_agent}
+    headers = {"Accept": "application/json", "User-Agent": config["user_agent"]}
     # from 'npm token create --read-only' to give us a higher rate limit
-    if args.npm_auth_token:
-        headers["Authorization"] = f"Bearer {args.npm_auth_token}"
+    if config.get("npm_auth_token", None):
+        headers["Authorization"] = f"Bearer {config['npm_auth_token']}"
 
     return aiohttp.ClientSession(
         headers=headers,
-        timeout=aiohttp.ClientTimeout(total=args.total_timeout),
-        connector=aiohttp.TCPConnector(limit=args.max_connections),
+        timeout=aiohttp.ClientTimeout(total=config["total_timeout"]),
+        connector=aiohttp.TCPConnector(limit=config["max_connections"]),
         raise_for_status=True,
     )
 
@@ -69,29 +77,31 @@ def is_not_found_exception(err: Exception) -> bool:
 
 
 async def fetch_npm_registry_metadata(
-    args: argparse.Namespace, package_names: Iterable[str], total_packages: int = None
+    config: NPMRegistryClientConfig,
+    package_names: Iterable[str],
+    total_packages: int = None,
 ) -> AsyncGenerator[Dict[str, Dict], None]:
     """
     Fetches npm registry metadata for one or more node package names
     """
     total_groups: Optional[int] = None
     if total_packages:
-        total_groups = math.ceil(total_packages / args.package_batch_size)
-    async with aiohttp_session(args) as s:
+        total_groups = math.ceil(total_packages / config["package_batch_size"])
+    async with aiohttp_session(config) as s:
         async_query_with_backoff = backoff.on_exception(
             backoff.expo,
             (aiohttp.ClientResponseError, aiohttp.ClientError, asyncio.TimeoutError),
-            max_tries=args.max_retries,
+            max_tries=config["max_retries"],
             giveup=is_not_found_exception,
             logger=log,
         )(async_query)
 
-        for i, group in enumerate(grouper(package_names, args.package_batch_size)):
+        for i, group in enumerate(grouper(package_names, config["package_batch_size"])):
             log.info(f"fetching group {i} of {total_groups}")
             try:
                 group_results = await asyncio.gather(
                     *[
-                        async_query_with_backoff(s, package_name, args.dry_run)
+                        async_query_with_backoff(s, package_name, config["dry_run"])
                         for package_name in group
                         if package_name is not None
                     ]

--- a/depobs/scanner/clients/npm_registry.py
+++ b/depobs/scanner/clients/npm_registry.py
@@ -79,7 +79,7 @@ def is_not_found_exception(err: Exception) -> bool:
 async def fetch_npm_registry_metadata(
     config: NPMRegistryClientConfig,
     package_names: Iterable[str],
-    total_packages: int = None,
+    total_packages: Optional[int] = None,
 ) -> AsyncGenerator[Dict[str, Dict], None]:
     """
     Fetches npm registry metadata for one or more node package names

--- a/depobs/scanner/clients/npmsio.py
+++ b/depobs/scanner/clients/npmsio.py
@@ -1,25 +1,31 @@
-import argparse
 import asyncio
 import logging
 from typing import Any, AsyncGenerator, Dict, Iterable, Optional
 
 import aiohttp
 
+from depobs.scanner.clients.aiohttp_client_config import AIOHTTPClientConfig
 from depobs.util.serialize_util import grouper
 from depobs.scanner.models.package_meta_result import Result
 
 log = logging.getLogger(__name__)
 
 
-def aiohttp_session(args: argparse.Namespace) -> aiohttp.ClientSession:
+class NPMSIOClientConfig(
+    AIOHTTPClientConfig, total=False
+):  # don't require keys defined below
+    pass
+
+
+def aiohttp_session(config: NPMSIOClientConfig) -> aiohttp.ClientSession:
     return aiohttp.ClientSession(
         headers={
             "Accept": "application/json",
             "Content-Type": "application/json",
-            "User-Agent": args.user_agent,
+            "User-Agent": config["user_agent"],
         },
-        timeout=aiohttp.ClientTimeout(total=args.total_timeout),
-        connector=aiohttp.TCPConnector(limit=args.max_connections),
+        timeout=aiohttp.ClientTimeout(total=config["total_timeout"]),
+        connector=aiohttp.TCPConnector(limit=config["max_connections"]),
         raise_for_status=True,
     )
 
@@ -40,14 +46,14 @@ async def async_query(
 
 
 async def fetch_npmsio_scores(
-    args: argparse.Namespace, package_names: Iterable[str], total_packages: int = None
+    config: NPMSIOClientConfig, package_names: Iterable[str], total_packages: int = None
 ) -> AsyncGenerator[Result[Dict[str, Dict]], None]:
     """
     Fetches npms.io score and analysis for one or more node package names
 
     Uses: https://api-docs.npms.io/#api-Package-GetMultiPackageInfo
     """
-    async with aiohttp_session(args) as s:
+    async with aiohttp_session(config) as s:
         group_results = await asyncio.gather(
             *[
                 async_query(
@@ -57,9 +63,9 @@ async def fetch_npmsio_scores(
                         for package_name in group
                         if package_name is not None
                     ],
-                    args.dry_run,
+                    config["dry_run"],
                 )
-                for group in grouper(package_names, args.package_batch_size)
+                for group in grouper(package_names, config["package_batch_size"])
                 if group is not None
             ]
         )

--- a/depobs/scanner/clients/npmsio.py
+++ b/depobs/scanner/clients/npmsio.py
@@ -46,7 +46,9 @@ async def async_query(
 
 
 async def fetch_npmsio_scores(
-    config: NPMSIOClientConfig, package_names: Iterable[str], total_packages: int = None
+    config: NPMSIOClientConfig,
+    package_names: Iterable[str],
+    total_packages: Optional[int] = None,
 ) -> AsyncGenerator[Result[Dict[str, Dict]], None]:
     """
     Fetches npms.io score and analysis for one or more node package names

--- a/depobs/scanner/docker/containers.py
+++ b/depobs/scanner/docker/containers.py
@@ -298,10 +298,7 @@ async def build(dockerfile: bytes, tag: str, pull: bool = False) -> str:
 
 
 async def ensure_repo(
-    container: aiodocker.containers.DockerContainer,
-    repo_url: str,
-    git_clean=True,
-    working_dir="/",
+    container: aiodocker.containers.DockerContainer, repo_url: str, working_dir="/",
 ) -> None:
     test_repo_exec: Exec = await container.run(
         f"test -d repo", wait=True, check=False, working_dir=working_dir
@@ -314,8 +311,6 @@ async def ensure_repo(
         )
         # TODO: for multiple repos make sure the repo remote matches repo_url
         cmds = [("git remote get-url origin", True)]
-        if git_clean:
-            cmds.append(("git clean -f -d -x -q", True))
         working_dir += "repo"
     else:
         cmds = [

--- a/depobs/scanner/graph_util.py
+++ b/depobs/scanner/graph_util.py
@@ -1,4 +1,3 @@
-import argparse
 import logging
 from typing import (
     AbstractSet,
@@ -66,10 +65,10 @@ def npm_packages_to_networkx_digraph(packages: Iterable[NPMPackage]) -> nx.DiGra
 
 
 def rust_crates_and_packages_to_networkx_digraph(
-    args: argparse.Namespace,
+    args: Any,  # TODO: define TypedDict for graphing display options
     crates_and_packages: Tuple[Dict[str, RustCrate], Dict[str, RustPackage]],
 ) -> nx.DiGraph:
-    log.debug("graphing with args: {}".format(args))
+    log.debug(f"graphing with args: {args}")
     crates, packages = crates_and_packages
 
     node_id_format = NODE_ID_FORMATS[args.node_key]

--- a/depobs/scanner/pipelines/run_repo_tasks.py
+++ b/depobs/scanner/pipelines/run_repo_tasks.py
@@ -64,10 +64,6 @@ class RunRepoTasksConfig(TypedDict):
     # Print commands we would run and their context, but don't run them.
     dry_run: bool
 
-    # Only run against matching directory. e.g. './' for root directory or
-    # './packages/fxa-js-client/' for a subdirectory
-    dir: str
-
     # Languages to run commands for. Defaults to all of them.
     # choices=language_names
     languages: List[str]
@@ -324,17 +320,6 @@ async def run_pipeline(
         org_repo, git_ref = file_rows[0][0:2]
 
         log.debug(f"in {dep_file_parent_key!r} with files {files}")
-        if config["dir"] is not None:
-            if pathlib.PurePath(config["dir"]) != dep_file_parent_key:
-                log.debug(
-                    f"Skipping non-matching folder {dep_file_parent_key} for glob {config['dir']}"
-                )
-                continue
-            else:
-                log.debug(
-                    f"matching folder {dep_file_parent_key!r} for glob {config['dir']!r}"
-                )
-
         for lang, pm, image, version_commands, tasks in task_envs:
             if config["dry_run"]:
                 log.info(

--- a/depobs/scanner/pipelines/run_repo_tasks.py
+++ b/depobs/scanner/pipelines/run_repo_tasks.py
@@ -78,19 +78,19 @@ class RunRepoTasksConfig(TypedDict):
 
     # Languages to run commands for. Defaults to all of them.
     # choices=language_names
-    language: List[str]
+    languages: List[str]
 
     # Package managers to run commands for. Defaults to all of them.
     # choices=package_manager_names,
-    package_manager: List[str]
+    package_managers: List[str]
 
     # Docker images to run commands in. Defaults to all of them.
     # choices=docker_image_names,
-    docker_image: List[str]
+    docker_images: List[str]
 
     # Run install, list_metadata, or audit tasks in the order
     # provided. Defaults to none of them
-    repo_task: List[str]
+    repo_tasks: List[str]
 
 
 async def run_task(
@@ -258,18 +258,18 @@ def iter_task_envs(
     None,
     None,
 ]:
-    enabled_languages = config["language"] or language_names
-    if not config["language"]:
+    enabled_languages = config["languages"] or language_names
+    if not config["languages"]:
         log.debug(f"languages not specified using all of {enabled_languages}")
 
-    enabled_package_managers = config["package_manager"] or package_manager_names
-    if not config["package_manager"]:
+    enabled_package_managers = config["package_managers"] or package_manager_names
+    if not config["package_managers"]:
         log.debug(
             f"package managers not specified using all of {enabled_package_managers}"
         )
 
-    enabled_image_names = config["docker_image"] or docker_image_names
-    if not config["docker_image"]:
+    enabled_image_names = config["docker_images"] or docker_image_names
+    if not config["docker_images"]:
         log.debug(
             f"docker image names not specified using all of {enabled_image_names}"
         )
@@ -292,7 +292,7 @@ def iter_task_envs(
             *[pm.version_commands for pm in language.package_managers.values()],
         )
         tasks: List[ContainerTask] = [
-            package_manager.tasks[task_name] for task_name in config["repo_task"]
+            package_manager.tasks[task_name] for task_name in config["repo_tasks"]
         ]
         yield language, package_manager, image, version_commands, tasks
 

--- a/depobs/scanner/pipelines/run_repo_tasks.py
+++ b/depobs/scanner/pipelines/run_repo_tasks.py
@@ -64,9 +64,6 @@ class RunRepoTasksConfig(TypedDict):
     # Print commands we would run and their context, but don't run them.
     dry_run: bool
 
-    # Run 'git clean -fdx' for each ref to clear package manager caches. Slower but better isolation.
-    git_clean: bool # TODO: default to false
-
     # Only run against matching directory. e.g. './' for root directory or
     # './packages/fxa-js-client/' for a subdirectory
     dir: str
@@ -153,10 +150,7 @@ async def run_in_repo_at_ref(
     ) as c:
         await c.run("mkdir -p /repos", wait=True, check=True)
         await containers.ensure_repo(
-            c,
-            org_repo.github_clone_url,
-            git_clean=config["git_clean"],
-            working_dir="/repos/",
+            c, org_repo.github_clone_url, working_dir="/repos/",
         )
         await containers.ensure_ref(c, git_ref, working_dir="/repos/repo")
         branch, commit, tag, *version_results = await asyncio.gather(

--- a/depobs/scanner/pipelines/run_repo_tasks.py
+++ b/depobs/scanner/pipelines/run_repo_tasks.py
@@ -20,11 +20,11 @@ from typing import (
     Generator,
     Iterable,
     List,
+    Mapping,
     Optional,
     Tuple,
     Union,
 )
-import typing
 
 from depobs.util.serialize_util import (
     get_in,
@@ -177,7 +177,7 @@ async def run_in_repo_at_ref(
     args: argparse.Namespace,
     item: Tuple[OrgRepo, GitRef, pathlib.Path],
     tasks: List[ContainerTask],
-    version_commands: typing.Mapping[str, str],
+    version_commands: Mapping[str, str],
     dry_run: bool,
     cwd_files: AbstractSet[str],
     file_rows: List[DependencyFile],

--- a/depobs/website/config.py
+++ b/depobs/website/config.py
@@ -117,7 +117,7 @@ CELERYD_TASK_TIME_LIMIT = 3600
 # depobs.scanner config
 
 _aiohttp_args = dict(
-    # User agent to user to query third party APIs
+    # User agent to use to query third party APIs
     user_agent="https://github.com/mozilla-services/dependency-observatory-scanner (foxsec+dependency+observatory@mozilla.com)",
     # aiohttp total timeout in seconds
     total_timeout=300,

--- a/depobs/website/config.py
+++ b/depobs/website/config.py
@@ -155,14 +155,15 @@ _docker_args = dict(
     docker_build=True,
     # non-default docker images to use for the task
     docker_image=[],
+    # Print commands we would run and their context, but don't run them
+    dry_run=False,
 )
 
 SCAN_NPM_TARBALL_ARGS = {
     **_docker_args,
     **dict(
-        dry_run=False,
-        language=["nodejs"],
-        package_manager=["npm"],
-        repo_task=["install", "list_metadata", "audit"],
+        languages=["nodejs"],
+        package_managers=["npm"],
+        repo_tasks=["install", "list_metadata", "audit"],
     ),
 }

--- a/depobs/website/config.py
+++ b/depobs/website/config.py
@@ -117,22 +117,26 @@ CELERYD_TASK_TIME_LIMIT = 3600
 # depobs.scanner config
 
 _aiohttp_args = dict(
-    # User agent to use to query third party APIs
-    user_agent="https://github.com/mozilla-services/dependency-observatory-scanner (foxsec+dependency+observatory@mozilla.com)",
-    # aiohttp total timeout in seconds
-    total_timeout=300,
-    # number of simultaneous connections to open
-    max_connections=10,
     # time to sleep between requests in seconds
     delay=0.5,
+    # don't hit the third part API just print intended actions
+    dry_run=False,
+    # number of simultaneous connections to open
+    max_connections=10,
+    # number of times to retry requests
+    max_retries=1,
+    # number of packages to fetch in once request (for APIs that support it)
+    package_batch_size=1,
+    # aiohttp total timeout in seconds
+    total_timeout=300,
+    # user agent to use to query third party APIs
+    user_agent="https://github.com/mozilla-services/dependency-observatory-scanner (foxsec+dependency+observatory@mozilla.com)",
 )
 
 
 NPM_CLIENT = {
     **_aiohttp_args,
-    "max_retries": 1,
     "package_batch_size": 10,
-    "dry_run": False,
     # an npm registry access token for fetch_npm_registry_metadata. Defaults NPM_PAT env var. Should be read-only.
     "npm_auth_token": os.environ.get("NPM_PAT", None),
 }
@@ -141,7 +145,6 @@ NPMSIO_CLIENT = {
     **_aiohttp_args,
     "max_connections": 1,
     "package_batch_size": 50,
-    "dry_run": False,
 }
 
 # shared docker args for multiple tasks

--- a/depobs/website/views.py
+++ b/depobs/website/views.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 import logging
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from flask import (
     abort,

--- a/depobs/worker/tasks.py
+++ b/depobs/worker/tasks.py
@@ -83,7 +83,7 @@ app = create_celery_app()
 
 
 @app.task()
-def add(x, y):
+def add(x: int, y: int) -> int:
     return x + y
 
 

--- a/depobs/worker/tasks.py
+++ b/depobs/worker/tasks.py
@@ -174,7 +174,7 @@ async def scan_tarball_url(
 @app.task(bind=True)
 def scan_npm_package(
     self: celery.Task, package_name: str, package_version: Optional[str] = None
-) -> None:
+) -> Tuple[str, Optional[str]]:
     package_name_validation_error = validators.get_npm_package_name_validation_error(
         package_name
     )

--- a/depobs/worker/tasks.py
+++ b/depobs/worker/tasks.py
@@ -131,7 +131,7 @@ async def scan_tarball_url(
             log.info(
                 f"for {lang.name} {pm.name} would run in {image.local.repo_name_tag}"
                 f" {list(version_commands.values())} concurrently then"
-                f" {[t.command for t in tasks]} "
+                f" {[t.command for t in container_tasks]} "
             )
             continue
 

--- a/depobs/worker/tasks.py
+++ b/depobs/worker/tasks.py
@@ -98,8 +98,8 @@ async def scan_tarball_url(
     the run_repo_task result object (from running the repo tasks
     commands in a container).
     """
-    task_envs: Tuple[
-        Language, PackageManager, DockerImage, ChainMap, List[ContainerTask]
+    task_envs: List[
+        Tuple[Language, PackageManager, DockerImage, ChainMap, List[ContainerTask]]
     ] = list(iter_task_envs(args))
     if args.docker_build:
         await build_images_for_envs(args, task_envs)

--- a/depobs/worker/tasks.py
+++ b/depobs/worker/tasks.py
@@ -9,6 +9,7 @@ import sys
 from typing import (
     AbstractSet,
     Any,
+    AsyncGenerator,
     Callable,
     Dict,
     Generator,
@@ -56,6 +57,7 @@ from depobs.database.models import (
     PackageVersion,
     PackageGraph,
 )
+from depobs.scanner.models.package_meta_result import Result
 from depobs.scanner.pipelines.postprocess import postprocess_task
 from depobs.scanner.pipelines.run_repo_tasks import (
     iter_task_envs,
@@ -286,7 +288,10 @@ def scan_npm_package_then_build_report_tree(
 
 
 async def fetch_package_data(
-    fetcher: Callable[[Type[AIOHTTPClientConfig], List[str], int], Dict],
+    fetcher: Callable[
+        [Type[AIOHTTPClientConfig], List[str], Optional[int]],
+        AsyncGenerator[Result[Dict[str, Dict]], None],
+    ],
     config: Type[AIOHTTPClientConfig],
     package_names: List[str],
 ) -> List[Dict]:

--- a/depobs/worker/tasks.py
+++ b/depobs/worker/tasks.py
@@ -16,6 +16,7 @@ from typing import (
     List,
     Optional,
     Tuple,
+    Type,
     Union,
 )
 import logging
@@ -48,6 +49,7 @@ import depobs.worker.validators as validators
 
 # import exc_to_str to resolve import cycle for the following depobs.scanner.clients
 from depobs.scanner.pipelines.util import exc_to_str as _
+from depobs.scanner.clients.aiohttp_client_config import AIOHTTPClientConfig
 from depobs.scanner.clients.npmsio import fetch_npmsio_scores
 from depobs.scanner.clients.npm_registry import fetch_npm_registry_metadata
 from depobs.database.models import (
@@ -284,12 +286,12 @@ def scan_npm_package_then_build_report_tree(
 
 
 async def fetch_package_data(
-    fetcher: Callable[[argparse.Namespace, List[str], int], Dict],
-    args: argparse.Namespace,
+    fetcher: Callable[[Type[AIOHTTPClientConfig], List[str], int], Dict],
+    config: Type[AIOHTTPClientConfig],
     package_names: List[str],
 ) -> List[Dict]:
     package_results = []
-    async for package_result in fetcher(args, package_names, len(package_names)):
+    async for package_result in fetcher(config, package_names, len(package_names)):
         if isinstance(package_result, Exception):
             raise package_result
         package_results.append(package_result)

--- a/depobs/worker/tasks.py
+++ b/depobs/worker/tasks.py
@@ -304,9 +304,7 @@ def fetch_and_save_npmsio_scores(package_names: Iterable[str]) -> List[Dict]:
     log.debug(f"fetching npmsio scores for package names: {list(package_names)}")
     npmsio_scores: List[Dict] = asyncio.run(
         fetch_package_data(
-            fetch_npmsio_scores,
-            argparse.Namespace(**current_app.config["NPMSIO_CLIENT"]),
-            package_names,
+            fetch_npmsio_scores, current_app.config["NPMSIO_CLIENT"], package_names,
         ),
         debug=False,
     )

--- a/depobs/worker/tasks.py
+++ b/depobs/worker/tasks.py
@@ -305,7 +305,8 @@ async def fetch_package_data(
     package_names: List[str],
 ) -> List[Dict]:
     package_results = []
-    async for package_result in fetcher(config, package_names, len(package_names)):
+    # TODO: figure this type error out later
+    async for package_result in fetcher(config, package_names, len(package_names)):  # type: ignore
         if isinstance(package_result, Exception):
             raise package_result
         package_results.append(package_result)

--- a/depobs/worker/tasks.py
+++ b/depobs/worker/tasks.py
@@ -330,7 +330,7 @@ def fetch_and_save_registry_entries(package_names: Iterable[str]) -> List[Dict]:
     npm_registry_entries = asyncio.run(
         fetch_package_data(
             fetch_npm_registry_metadata,
-            argparse.Namespace(**current_app.config["NPM_CLIENT"]),
+            current_app.config["NPM_CLIENT"],
             package_names,
         ),
         debug=False,

--- a/depobs/worker/tasks.py
+++ b/depobs/worker/tasks.py
@@ -17,8 +17,7 @@ from typing import (
     List,
     Optional,
     Tuple,
-    Type,
-    Union,
+    TypeVar,
 )
 import logging
 
@@ -50,9 +49,11 @@ import depobs.worker.validators as validators
 
 # import exc_to_str to resolve import cycle for the following depobs.scanner.clients
 from depobs.scanner.pipelines.util import exc_to_str as _
-from depobs.scanner.clients.aiohttp_client_config import AIOHTTPClientConfig
-from depobs.scanner.clients.npmsio import fetch_npmsio_scores
-from depobs.scanner.clients.npm_registry import fetch_npm_registry_metadata
+from depobs.scanner.clients.npmsio import fetch_npmsio_scores, NPMSIOClientConfig
+from depobs.scanner.clients.npm_registry import (
+    fetch_npm_registry_metadata,
+    NPMRegistryClientConfig,
+)
 from depobs.database.models import (
     PackageVersion,
     PackageGraph,
@@ -289,12 +290,18 @@ def scan_npm_package_then_build_report_tree(
     )
 
 
+# fetch_package_data should take fetcher and config params with matching config
+# types i.e. do not not let fetcher take an NPMSIOClientConfig with config
+# NPMRegistryClientConfig
+ClientConfig = TypeVar("ClientConfig", NPMSIOClientConfig, NPMRegistryClientConfig)
+
+
 async def fetch_package_data(
     fetcher: Callable[
-        [Type[AIOHTTPClientConfig], List[str], Optional[int]],
+        [ClientConfig, Iterable[str], Optional[int]],
         AsyncGenerator[Result[Dict[str, Dict]], None],
     ],
-    config: Type[AIOHTTPClientConfig],
+    config: ClientConfig,
     package_names: List[str],
 ) -> List[Dict]:
     package_results = []

--- a/depobs/worker/tasks.py
+++ b/depobs/worker/tasks.py
@@ -104,7 +104,7 @@ async def scan_tarball_url(
     if args.docker_build:
         await build_images_for_envs(args, task_envs)
 
-    assert len(task_envs) == 1
+    assert len(task_envs) == 1, "scan_tarball_url: No task envs found to run tasks"
     for lang, pm, image, version_commands, container_tasks in task_envs:
         # TODO: add as new command in depobs.scanner.models.language?
         # write a package.json file to so npm audit doesn't error out
@@ -169,6 +169,8 @@ async def scan_tarball_url(
                 task_results=[tr for tr in task_results if isinstance(tr, dict)],
             )
             return result
+    # dry run
+    return dict(task_results=[])
 
 
 @app.task(bind=True)
@@ -203,7 +205,7 @@ def scan_npm_package(
         if tarball_url:
             # start an npm container, install the tarball, run list and audit
             # assert tarball_url == f"https://registry.npmjs.org/{package_name}/-/{package_name}-{package_version}.tgz
-            container_task_results = asyncio.run(
+            container_task_results: Dict[str, Any] = asyncio.run(
                 scan_tarball_url(
                     argparse.Namespace(**current_app.config["SCAN_NPM_TARBALL_ARGS"]),
                     tarball_url,

--- a/depobs/worker/tasks.py
+++ b/depobs/worker/tasks.py
@@ -272,7 +272,7 @@ def build_report_tree(package_version_tuple: Tuple[str, str]) -> None:
     )
     if db_graph is None:
         log.info(f"{package.name} {package.version} has no children")
-        db_graph: PackageGraph = PackageGraph(id=None, link_ids=[])
+        db_graph = PackageGraph(id=None, link_ids=[])
         db_graph.distinct_package_ids = set([package.id])
 
     store_package_reports(scoring.score_package_graph(db_graph))

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,8 @@ files =
       depobs/scanner/pipelines/__init__.py,
       depobs/database/models.py,
       depobs/util/*.py,
-      depobs/worker/scoring.py
+      depobs/worker/scoring.py,
+      depobs/worker/tasks.py
 
 python_version = 3.8
 # compose mounts . into /app and mypy can't write to its default .mypy_cache dir


### PR DESCRIPTION
Changes:

* replaces some argparse namespaces with configs for #162
* enable type checking `worker.tasks`
* pluralize run repo tasks config var names for lists
* delete a bunch of run repo tasks code