### PR TITLE
web: return 502 for errorred scans

### DIFF
--- a/depobs/website/views.py
+++ b/depobs/website/views.py
@@ -159,7 +159,7 @@ def handle_package_report_not_found(e):
     package_report = models.get_placeholder_entry(package_name, package_version)
     if package_report:
         if package_report.status == "error":
-            return package_report.report_json, 500
+            return package_report.report_json, 502
         return package_report.report_json, 202
 
     if not check_package_name_registered(package_name):

--- a/tests/website/test_api.py
+++ b/tests/website/test_api.py
@@ -19,7 +19,7 @@ def delete_reports(models, package_name, package_version):
     models.db.session.commit()
 
 
-def test_found_package_report_with_error_status_returns_500(models, client):
+def test_found_package_report_with_error_status_returns_502(models, client):
     delete_reports(models, "dep-obs-internal-wokka-wokka", "0.0.1")
     add_report(
         models,
@@ -31,7 +31,7 @@ def test_found_package_report_with_error_status_returns_500(models, client):
     response = client.get(
         "/package?package_name=dep-obs-internal-wokka-wokka&package_version=0.0.1"
     )
-    assert response.status == "500 INTERNAL SERVER ERROR"
+    assert response.status == "502 BAD GATEWAY"
 
 
 def test_found_package_report_without_score_returns_202(models, client):


### PR DESCRIPTION
Pretend the worker is an upstream service returning 500 was confusing to debug.