### PR TITLE
Install gcloud sdk in container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,15 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
             libpq-dev \
             graphviz \
             jq \
-            curl
+            curl \
+            gnupg
+
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | \
+    tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+      curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
+      apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && \
+      apt-get update -y && \
+      apt-get install google-cloud-sdk -y
 
 WORKDIR /app
 


### PR DESCRIPTION
gcloud is needed to auth the client with the jobs kubernetes cluster