### PR TITLE
Allow local development to access gcp pubsub

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -24,6 +24,11 @@ $ minikube start
 🌟  Enabled addons: default-storageclass, storage-provisioner
 🏄  Done! kubectl is now configured to use "minikube"
 ```
+1. Create a kubernetes secret with GCP Service Account key for the `dev-local`
+Service Account in the depobs-nonprod project.
+```
+kubectl create secret generic dev-local-service-account --from-file=key.json=<path/to/KEYFILE.json>
+```
 
 1. From the project root, run `kubectl create -f kubernetes/` to start DO (use `kubectl delete -f kubernetes/` to remote it):
 

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -83,15 +83,23 @@ spec:
           value: "default"
         - name: UNTRUSTED_JOB_SERVICE_ACCOUNT_NAME
           value: ""
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: "/var/secrets/google/key.json"
         image: mozilla/dependency-observatory
         imagePullPolicy: IfNotPresent
         name: dependency-observatory-api
         ports:
         - containerPort: 8000
         resources: {}
+        volumeMounts:
+          - name: google-cloud-key
+            mountPath: /var/secrets/google
       restartPolicy: Always
       serviceAccountName: job-runner
-      volumes: null
+      volumes:
+      - name: google-cloud-key
+        secret:
+          secretName: dev-local-service-account
 status: {}
 
 ---


### PR DESCRIPTION
Instructions to create secret without committing to repo, then updates to api workload to use the service account key.