### PR TITLE
fix type-check CI failure clients additional_headers

### DIFF
--- a/depobs/clients/aiohttp_client.py
+++ b/depobs/clients/aiohttp_client.py
@@ -54,6 +54,7 @@ def aiohttp_session(config: AIOHTTPClientConfig) -> aiohttp.ClientSession:
         headers["Authorization"] = f"Bearer {config['bearer_auth_token']}"
     if config.get("additional_headers", None):
         additional_headers = config["additional_headers"]
+        assert additional_headers is not None
         for header in additional_headers:
             headers[header] = additional_headers[header]
 


### PR DESCRIPTION
CI was failing with despite the check on `if config.get("additional_headers", None):`

changing the following line to:

```python
            additional_headers: Dict[str, str] = config["additional_headers"]
```

also failed.

I believe this is related to typeddict newness, but a quick search didn't reveal an upstream issue in mypy.

```console
depobs/clients/aiohttp_client.py: note: In function "aiohttp_session":
depobs/clients/aiohttp_client.py:57:23: error: Item "None" of
"Optional[Dict[str, str]]" has no attribute "__iter__" (not iterable) 
[union-attr]
            for header in additional_headers:
                          ^
depobs/clients/aiohttp_client.py:58:31: error: Value of type
"Optional[Dict[str, str]]" is not indexable  [index]
                headers[header] = additional_headers[header]
                                  ^
Found 2 errors in 1 file (checked 35 source files)

Exited with code exit status 1
```

https://app.circleci.com/pipelines/github/mozilla-services/dependency-observatory/1059/workflows/5b37e0d4-7bf0-4c9e-9f0d-265ee2913277/jobs/3892