### PR TITLE
scan env updates

### DIFF
--- a/scan_envs/Dockerfile
+++ b/scan_envs/Dockerfile
@@ -9,7 +9,7 @@ RUN groupadd --gid 10001 app && \
 RUN install -o app -g app -d /var/run/app /var/log/app /home/app
 
 RUN apt-get -y update && apt-get install -y git jq ripgrep curl
-RUN cargo && cargo install cargo-audit || true
+RUN cargo --version && cargo install cargo-audit || true
 
 RUN mkdir -p /opt
 COPY docker-entrypoint.sh /opt

--- a/scan_envs/Dockerfile
+++ b/scan_envs/Dockerfile
@@ -8,7 +8,7 @@ RUN groupadd --gid 10001 app && \
       --home-dir /home/app/ app
 RUN install -o app -g app -d /var/run/app /var/log/app /home/app
 
-RUN apt-get -y update && apt-get install -y git jq ripgrep
+RUN apt-get -y update && apt-get install -y git jq ripgrep curl
 
 RUN mkdir -p /opt
 COPY docker-entrypoint.sh /opt

--- a/scan_envs/Dockerfile
+++ b/scan_envs/Dockerfile
@@ -9,6 +9,7 @@ RUN groupadd --gid 10001 app && \
 RUN install -o app -g app -d /var/run/app /var/log/app /home/app
 
 RUN apt-get -y update && apt-get install -y git jq ripgrep curl
+RUN cargo && cargo install cargo-audit || true
 
 RUN mkdir -p /opt
 COPY docker-entrypoint.sh /opt

--- a/scan_envs/Dockerfile
+++ b/scan_envs/Dockerfile
@@ -8,7 +8,24 @@ RUN groupadd --gid 10001 app && \
       --home-dir /home/app/ app
 RUN install -o app -g app -d /var/run/app /var/log/app /home/app
 
-RUN apt-get -y update && apt-get install -y git jq ripgrep curl
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
+    apt-get install --no-install-recommends -y \
+	    curl \
+	    git \
+	    jq \
+	    ripgrep \
+            apt-transport-https \
+            ca-certificates \
+            curl \
+            gnupg
+
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" | \
+    tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
+      curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
+      apt-key --keyring /usr/share/keyrings/cloud.google.gpg  add - && \
+      DEBIAN_FRONTEND=noninteractive apt-get update -y && \
+      apt-get install google-cloud-sdk -y
+
 RUN cargo --version && cargo install cargo-audit || true
 
 RUN mkdir -p /opt

--- a/util/build_scan_images.sh
+++ b/util/build_scan_images.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+eval $(minikube -p minikube docker-env)
+
+# build scan images
+docker build --build-arg=BASE_NAME=node --build-arg=BASE_VERSION=12-buster-slim -t mozilla/dependency-observatory:node-12 ./scan_envs
+docker build --build-arg=BASE_NAME=node --build-arg=BASE_VERSION=10-buster-slim -t mozilla/dependency-observatory:node-10 ./scan_envs
+docker build --build-arg=BASE_NAME=rust --build-arg=BASE_VERSION=1-slim-buster -t mozilla/dependency-observatory:rust-1 ./scan_envs


### PR DESCRIPTION
refs: #404 

Changes:

* add curl and gcloud to scan images
* install cargo audit in rust scan image
* add `util/build_scan_images.sh` to build scan images without `docker-compose` to use with the minikube docker
* have gcloud cache config at `CLOUDSDK_CONFIG` in a temp dir 
* tee output to a temp file and publish it to pubsub as one message (up to 10MB, but haven't run into that limit yet)
* add env vars:
  * `CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE` to configure gcloud for use outside GCP
  * `GCP_PROJECT_ID` to set the default gcloud project
  * `GCP_PUBSUB_TOPIC` where to publish messages
  * `JOB_NAME` the k8s job name for joining with the initial scan request