### PR TITLE
add worker process config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+
+format:
+	black .
+
+type-check:
+	mypy --config setup.cfg
+
+build-image:
+	./util/build_image.sh
+
+build-scan-images:
+	./util/build_scan_images.sh
+
+redeploy:
+	./util/redeploy_image.sh
+
+recreate:
+	./util/recreate_cluster.sh
+
+port-forward:
+	kubectl -n default port-forward svc/api 8000
+
+
+api-shell:
+	kubectl exec -it svc/api -- /bin/bash
+
+db-shell:
+	kubectl exec -it svc/db -- /bin/bash -c 'su postgres'
+
+worker-shell:
+	kubectl exec -it deployments/worker -- /bin/bash
+
+api-flask-shell:
+	kubectl exec -it svc/api -- /bin/bash -c 'flask shell'
+
+worker-flask-shell:
+	kubectl exec -it deployments/worker -- /bin/bash -c 'flask shell'
+
+db-psql-shell:
+	kubectl exec -it svc/db -- /bin/bash -c 'su postgres -c "psql dependency_observatory"'
+
+# NB: not interactive no tty
+db-save-json-results:
+	kubectl exec svc/db -- /bin/bash -c 'su postgres -c "psql --csv -a dependency_observatory -c \"SELECT * FROM json_results\""' > json_results.csv
+
+shellcheck:
+	shellcheck bin/*.sh util/*.sh scan_envs/*.sh

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -30,8 +30,7 @@ if [ "$1" = 'web' ]; then
 elif [ "$1" = 'web-dev' ]; then
     python depobs/website/do.py
 elif [ "$1" = 'worker' ]; then
-    shift
-    python depobs/worker/main.py "$@"
+    python depobs/worker/main.py run
 else
     echo "got unrecognized command:" "$1"
     exit 1

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -30,6 +30,8 @@ Service Account in the depobs-nonprod project.
 kubectl create secret generic dev-local-service-account --from-file=key.json=<path/to/KEYFILE.json>
 ```
 
+1. Change the `GCP_PROJECT_ID` from `replaceme` in the worker deployment
+
 1. From the project root, run `kubectl create -f kubernetes/` to start DO (use `kubectl delete -f kubernetes/` to remote it):
 
 ```console

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -12,9 +12,6 @@ metadata:
   namespace: default
   name: job-admin
 rules:
-- apiGroups: [""] # resource for accessing Pod
-  resources: ["pods", "pods/log"]
-  verbs: ["get", "list", "watch"]
 - apiGroups: ["batch", "extensions"]
   resources: ["jobs"]
   verbs: ["read", "list", "watch", "create", "update", "patch", "replace", "delete"]

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -197,6 +197,10 @@ spec:
           value: postgresql+psycopg2://postgres:postgres@db/dependency_observatory
         - name: GCP_PROJECT_ID
           value: replaceme
+        - name: JOB_STATUS_PUBSUB_TOPIC
+          value: job-status-dev
+        - name: JOB_STATUS_PUBSUB_SUBSCRIPTION
+          value: job-status-dev
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: "/var/secrets/google/key.json"
         image: mozilla/dependency-observatory

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -77,29 +77,14 @@ spec:
           value: "1"
         - name: SQLALCHEMY_DATABASE_URI
           value: postgresql+psycopg2://postgres:postgres@db/dependency_observatory
-        - name: DEFAULT_JOB_SERVICE_ACCOUNT_NAME
-          value: "job-runner"
-        - name: UNTRUSTED_JOB_NAMESPACE
-          value: "default"
-        - name: UNTRUSTED_JOB_SERVICE_ACCOUNT_NAME
-          value: ""
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: "/var/secrets/google/key.json"
         image: mozilla/dependency-observatory
         imagePullPolicy: IfNotPresent
         name: dependency-observatory-api
         ports:
         - containerPort: 8000
         resources: {}
-        volumeMounts:
-          - name: google-cloud-key
-            mountPath: /var/secrets/google
       restartPolicy: Always
-      serviceAccountName: job-runner
-      volumes:
-      - name: google-cloud-key
-        secret:
-          secretName: dev-local-service-account
+      serviceAccountName: ""
 status: {}
 
 ---
@@ -178,3 +163,58 @@ spec:
     io.kompose.service: db
 status:
   loadBalancer: {}
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    io.kompose.service: worker
+  name: worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: worker
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose convert
+        kompose.version: 1.21.0 (HEAD)
+      labels:
+        io.kompose.service: worker
+    spec:
+      containers:
+      - args:
+        # - "init-gcloud-creds"
+        - "worker"
+        env:
+        - name: FLASK_APP
+          value: depobs.website.wsgi:app
+        - name: FLASK_ENV
+          value: development
+        - name: SQLALCHEMY_DATABASE_URI
+          value: postgresql+psycopg2://postgres:postgres@db/dependency_observatory
+        - name: GCP_PROJECT_ID
+          value: replaceme
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: "/var/secrets/google/key.json"
+        image: mozilla/dependency-observatory
+        imagePullPolicy: IfNotPresent
+        name: dependency-observatory-worker
+        ports:
+        - containerPort: 8000
+        resources: {}
+        volumeMounts:
+          - name: google-cloud-key
+            mountPath: /var/secrets/google
+      restartPolicy: Always
+      serviceAccountName: job-runner
+      volumes:
+      - name: google-cloud-key
+        secret:
+          secretName: dev-local-service-account
+status: {}

--- a/util/build_and_redeploy_image.sh
+++ b/util/build_and_redeploy_image.sh
@@ -10,7 +10,10 @@ docker build -t mozilla/dependency-observatory:latest .
 
 # update deployments
 kubectl set image deployments.app/api dependency-observatory-api=mozilla/dependency-observatory:latest
+kubectl set image deployments.app/worker dependency-observatory-worker=mozilla/dependency-observatory:latest
 
 # redeploy
 kubectl rollout restart deployment api
+kubectl rollout restart deployment worker
 kubectl rollout status deployment api
+kubectl rollout status deployment worker

--- a/util/build_image.sh
+++ b/util/build_image.sh
@@ -11,9 +11,3 @@ docker build -t mozilla/dependency-observatory:latest .
 # update deployments
 kubectl set image deployments.app/api dependency-observatory-api=mozilla/dependency-observatory:latest
 kubectl set image deployments.app/worker dependency-observatory-worker=mozilla/dependency-observatory:latest
-
-# redeploy
-kubectl rollout restart deployment api
-kubectl rollout restart deployment worker
-kubectl rollout status deployment api
-kubectl rollout status deployment worker

--- a/util/recreate_cluster.sh
+++ b/util/recreate_cluster.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+kubectl delete -f kubernetes/
+kubectl create -f kubernetes/

--- a/util/redeploy_image.sh
+++ b/util/redeploy_image.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+# redeploy
+kubectl rollout restart deployment api
+kubectl rollout restart deployment worker
+kubectl rollout status deployment api
+kubectl rollout status deployment worker


### PR DESCRIPTION
refs: #404 

Changes:
* Add makefile and refactor util scripts
* change main image worker command to call run (not implemented)
* in k8s:
    * drop pod logs perms for `job-admin` svc account
    * drop job-runner for api deployment
    * add worker deployment with secret mount and env vars for pubsub (`JOB_STATUS_PUBSUB_TOPIC` and `JOB_STATUS_PUBSUB_SUBSCRIPTION`) and GCP config (`GCP_PROJECT_ID` and `GOOGLE_APPLICATION_CREDENTIALS`)
    * remove env vars `DEFAULT_JOB_SERVICE_ACCOUNT_NAME`, `UNTRUSTED_JOB_NAMESPACE`, `UNTRUSTED_JOB_SERVICE_ACCOUNT_NAME`, and `GOOGLE_APPLICATION_CREDENTIALS` w/ secret mount from api deployment