### PR TITLE
web: show one json result per line one scan job logs page

### DIFF
--- a/depobs/website/templates/scan_job_logs.html
+++ b/depobs/website/templates/scan_job_logs.html
@@ -54,7 +54,8 @@
 
     <dl>
         <dd>
-            <pre><code>{% for result in results %}{{ result.data }}{% endfor %}</code></pre>
+            <pre><code>{% for result in results %}{{ result.data }}
+{% endfor %}</code></pre>
         </dd>
     </dl>
 </div>


### PR DESCRIPTION
Change:
* Add a newline to the template so scan logs don't all render to one very wide line