### PR TITLE
Fix 450 skip npm prerelease versions

### DIFF
--- a/depobs/worker/tasks.py
+++ b/depobs/worker/tasks.py
@@ -162,6 +162,11 @@ def scan_package_tarballs(scan: models.Scan) -> Generator[asyncio.Task, None, No
                 f"scan: {scan.id} skipping npm registry entry with null version {package_name}"
             )
             continue
+        elif not validators.is_npm_release_package_version(package_version):
+            log.warn(
+                f"scan: {scan.id} {package_name} skipping npm registry entry with pre-release version {package_version!r}"
+            )
+            continue
 
         log.info(f"scan: {scan.id} scanning {package_name}@{package_version}")
         # we need a source_url and git_head or a tarball url to install

--- a/depobs/worker/validators.py
+++ b/depobs/worker/validators.py
@@ -32,11 +32,11 @@ def get_npm_package_name_validation_error(package_name: str) -> Optional[Excepti
 #
 # https://docs.npmjs.com/misc/semver#versions
 NPM_PACKAGE_VERSION_RE = re.compile(
-    r"""(=v)?           # strip leading = and v
+    r"""^([=v])?           # strip leading = and v
 [0-9]+\.[0-9]+\.[0-9]+  # major minor and patch versions (TODO: check if positive ints)
 [-]?[-\.0-9A-Za-z]*       # optional pre-release version e.g. -alpha.1 (TODO: split out identifiers)
 [+]?[-\.0-9A-Za-z]*       # optional build metadata e.g. +exp.sha.5114f85
-""",
+$""",
     re.VERBOSE,
 )
 
@@ -52,3 +52,21 @@ def get_npm_package_version_validation_error(package_name: str) -> Optional[Exce
         )
 
     return None
+
+
+# Version must be parseable by node-semver, which is bundled with npm as a dependency.
+#
+# https://docs.npmjs.com/files/package.json#version
+#
+# https://docs.npmjs.com/misc/semver#versions
+NPM_PACKAGE_RELEASE_VERSION_RE = re.compile(
+    r"""^([=v])?           # strip leading = and v
+[0-9]+\.[0-9]+\.[0-9]+  # major minor and patch versions (TODO: check if positive ints)
+([+][-\.0-9A-Za-z]*)?     # optional build metadata e.g. 3+exp.sha.5114f85
+$""",
+    re.VERBOSE,
+)
+
+
+def is_npm_release_package_version(package_version: str) -> bool:
+    return bool(re.match(NPM_PACKAGE_RELEASE_VERSION_RE, package_version))

--- a/tests/worker/test_validators.py
+++ b/tests/worker/test_validators.py
@@ -2,7 +2,7 @@ from typing import Optional
 
 import pytest
 
-import depobs.worker.validators as validators
+import depobs.worker.validators as m
 
 
 @pytest.mark.parametrize(
@@ -25,9 +25,9 @@ def test_get_npm_package_name_validation_error(
     package_name: str, expected_validation_error: Optional[Exception]
 ) -> None:
     if expected_validation_error is None:
-        assert validators.get_npm_package_name_validation_error(package_name) is None
+        assert m.get_npm_package_name_validation_error(package_name) is None
     else:
-        err = validators.get_npm_package_name_validation_error(package_name)
+        err = m.get_npm_package_name_validation_error(package_name)
         print(f"got {err} {expected_validation_error}")
         assert isinstance(err, Exception)
         assert str(err) == str(expected_validation_error)
@@ -60,11 +60,38 @@ def test_get_npm_package_version_validation_error(
     package_version: str, expected_validation_error: Optional[Exception]
 ) -> None:
     if expected_validation_error is None:
-        assert (
-            validators.get_npm_package_version_validation_error(package_version) is None
-        )
+        assert m.get_npm_package_version_validation_error(package_version) is None
     else:
-        err = validators.get_npm_package_version_validation_error(package_version)
+        err = m.get_npm_package_version_validation_error(package_version)
         print(f"got {err} {expected_validation_error}")
         assert isinstance(err, Exception)
         assert str(err) == str(expected_validation_error)
+
+
+@pytest.mark.parametrize(
+    "package_version,is_release_version",
+    [
+        ("0.0.0", True),
+        ("v0.0.0", True),
+        ("0.0.0+exp.sha.5114f85", True),
+        ("v0.0.0-rc.1", False),
+        ("v0.0.0-rc1", False),
+        ("1.2.3-alpha.1+exp.sha.5114f85", False),
+        ("#!/usr/bin/env", False,),
+        ("1.0.0-rc.3", False),
+        ("1.0.0-beta", False),
+        ("1.0.0-beta2", False),
+        ("2.0.0-beta", False),
+        ("2.0.0-beta2", False),
+        ("2.0.0-beta3", False),
+        ("2.0.0-rc2", False),
+        ("3.0.0-alpha5", False),
+        ("3.0.0-beta7", False),
+        ("5.0.0-alpha.1", False),
+    ],
+)
+@pytest.mark.unit
+def test_get_npm_package_version_validation_error(
+    package_version: str, is_release_version: bool
+) -> None:
+    assert m.is_npm_release_package_version(package_version) == is_release_version


### PR DESCRIPTION
fixes: #450 and changes npm package version regex to match leading `v` without an `=`