### PR TITLE
add e2e-test $api_url [fixture_directory] to docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ COPY migrations migrations
 COPY bin bin
 COPY depobs depobs
 COPY version.json .
+COPY tests tests
 
 USER app
 ENTRYPOINT [ "/app/bin/docker-entrypoint.sh" ]

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -35,6 +35,10 @@ elif [ "$1" = 'worker' ]; then
     python depobs/worker/main.py run \
 	   --task-name save_pubsub \
 	   --task-name run_next_scan
+elif [ "$1" = 'e2e-test' ]; then
+    # e.g. e2e_test API_URL tests/fixtures/
+    shift
+    bin/e2e_test.sh "$@"
 else
     echo "got unrecognized command:" "$1"
     exit 1

--- a/bin/e2e_test.sh
+++ b/bin/e2e_test.sh
@@ -12,48 +12,45 @@ fi
 
 fixture_dir=$2
 if [[ "$fixture_dir" = "" ]]; then
-    fixture_dir="."
+    fixture_dir="./tests/fixtures"
 fi
 
 
 # check dockerflow
 echo "testing ${api_url}/__heartbeat__"
-diff -w "${fixture_dir}/tests/fixtures/__heartbeat__200.json" <(curl -sS "${api_url}/__heartbeat__" | jq "")
+diff -w "${fixture_dir}/__heartbeat__200.json" <(curl -sS "${api_url}/__heartbeat__" | jq "")
 echo "/__heartbeat__ matched expected output? (should be 0)" "$?"
 
 echo "testing ${api_url}/__lbheartbeat__"
-diff -w "${fixture_dir}/tests/fixtures/__lbheartbeat__200.json" <(curl -sS "${api_url}/__lbheartbeat__" | jq "")
+diff -w "${fixture_dir}/__lbheartbeat__200.json" <(curl -sS "${api_url}/__lbheartbeat__" | jq "")
 echo "/__lbheartbeat__ matched expected output? (should be 0)" "$?"
 
 echo "testing ${api_url}/__version__"
-diff -w "${fixture_dir}/tests/fixtures/__version__keys.json" <(curl -sS "${api_url}/__version__" | jq 'keys')
+diff -w "${fixture_dir}/__version__keys.json" <(curl -sS "${api_url}/__version__" | jq 'keys')
 echo "/__version__ returns expected keys? (should be 0)" "$?"
 
 
 # test scanning
-echo "testing ${api_url}/package_report?package_name=%40hapi%2Fbounce&package_version=2.0.0 runs and scores a scan"
-echo "sleeping for one second"
+scan_id=$(curl  -sSw '\n' -X POST -H 'Content-Type: application/json' -H 'Connection: keep-alive' --compressed --data-raw '{"package_manager": "npm", "package_name": "ip-reputation-js-client", "package_versions_type": "latest", "scan_type": "scan_score_npm_package"}' "${api_url}/api/v1/scans" | jq '.id')
+echo "started scan with id ${scan_id}"
+
+
+echo "sleeping for one second between progress checks"
 while :
 do
     sleep 1
-    response=$(curl -sSw '\n' "${api_url}/package_report?package_name=%40hapi%2Fbounce&package_version=2.0.0" | jq '')
-    task_status=$(echo -n "$response" | jq -rc '.task_status')
-    status=$(echo -n "$response" | jq -rc '.status')
-    echo ".task_status: ${task_status} .status: ${status}"
-    if [[ "$status" = 'error' ]]; then
+    status=$(curl -sSw '\n' "${api_url}/api/v1/scans/${scan_id}" | jq -r '.status')
+    echo "scan_status: ${status}"
+    if [[ "$status" = 'failed' ]]; then
         echo "scan task errored with response:"
         echo "$response"
         exit 1
     fi
-    if [[ "$task_status" = 'FAILURE' ]]; then
-        echo "queuing task failed with response:"
-        echo "$response"
-        exit 1
-    fi
 
-    if [[ "$status" = 'scanned' ]]; then
+    if [[ "$status" = 'succeeded' ]]; then
        break
     fi
 done
-echo "scan succeeded with response:"
+response=$(curl -sSw '\n' "${api_url}/package_report?package_manager=npm&package_name=ip-reputation-js-client&package_version=latest" | jq '')
+echo "scan succeeded. Report response:"
 echo "$response"


### PR DESCRIPTION
fixes: #239 (except for the load testing part)

functional test from within the image:

```console
$ make api-shell
app@api-7ddc676ccf-mqhj5:/app$ ./bin/e2e_test.sh
testing http://localhost:8000/__heartbeat__
/__heartbeat__ response matched fixture ./tests/fixtures/__heartbeat__200.json
testing http://localhost:8000/__lbheartbeat__
/__lbheartbeat__ matched fixture ./tests/fixtures/__lbheartbeat__200.json
testing http://localhost:8000/__version__
/__version__ keys matched fixture ./tests/fixtures/__version__keys.json
started scan with id 3
sleeping for one second between progress checks
scan_status: queued
scan_status: queued
scan_status: queued
scan_status: queued
scan_status: started
...
scan_status: started
scan_status: succeeded
scan succeeded. Report response:
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<title>Redirecting...</title>
<h1>Redirecting...</h1>
<p>You should be redirected automatically to target URL: <a href="/package_report?package_name=ip-reputation-js-client&amp;package_version=6.0.1&amp;package_manager=npm">/package_report?package_name=ip-reputation-js-client&amp;package_version=6.0.1&amp;package_manager=npm</a>.  If not click the link.
```

functional test from the docker entrypoint (NB: required build outside the minikube docker; port-forward and host network):

```console
$ docker run --net=host --rm mozilla/dependency-observatory:latest e2e-test http://localhost:8000
testing http://localhost:8000/__heartbeat__
/__heartbeat__ response matched fixture ./tests/fixtures/__heartbeat__200.json
testing http://localhost:8000/__lbheartbeat__
/__lbheartbeat__ matched fixture ./tests/fixtures/__lbheartbeat__200.json
testing http://localhost:8000/__version__
/__version__ keys matched fixture ./tests/fixtures/__version__keys.json
started scan with id 5
sleeping for one second between progress checks
scan_status: queued
scan_status: queued
scan_status: started
...
scan_status: started
scan_status: succeeded
scan succeeded. Report response:
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<title>Redirecting...</title>
<h1>Redirecting...</h1>
<p>You should be redirected automatically to target URL: <a href="/package_report?package_name=ip-reputation-js-client&amp;package_version=6.0.1&amp;package_manager=npm">/package_report?package_name=ip-reputation-js-client&amp;package_version=6.0.1&amp;package_manager=npm</a>.  If not click the link.
$
```