### PR TITLE
worker: don't delete jobs

### DIFF
--- a/depobs/worker/k8s.py
+++ b/depobs/worker/k8s.py
@@ -256,13 +256,4 @@ def run_job(
     """
     api_client = get_api_client(job_config["context_name"])
     job = create_job(job_config)
-    try:
-        yield job
-    finally:
-        kubernetes.client.BatchV1Api(api_client=api_client).delete_namespaced_job(
-            name=job_config["name"],
-            namespace=job_config["namespace"],
-            body=kubernetes.client.V1DeleteOptions(
-                propagation_policy="Foreground", grace_period_seconds=5
-            ),
-        )
+    yield job


### PR DESCRIPTION
manually clean up or use a job TTL

cc @erkolson we don't have TTL right now, so we'll have to clean up old jobs, but I think it'll help with debugging. 