### PR TITLE
enable strict mode and single-interpreter in uwsgi configs

### DIFF
--- a/web-uwsgi.ini
+++ b/web-uwsgi.ini
@@ -9,3 +9,5 @@ mount = /=depobs.website.wsgi:app
 static-map = /static=/app/depobs/website/static
 disable-logging = True
 die-on-term = True
+strict = true
+single-interpreter = true

--- a/worker-uwsgi.ini
+++ b/worker-uwsgi.ini
@@ -8,3 +8,5 @@ enable-threads = True
 mount = /=depobs.worker.wsgi:app
 disable-logging = True
 die-on-term = True
+strict = true
+single-interpreter = true


### PR DESCRIPTION
fail for unknown options and use one interpreter instead of hosting
multiple services